### PR TITLE
update the cover saver for demos BasicDQN_CartPole and BasicDQN_EmptyRoom

### DIFF
--- a/docs/experiments/experiments/DQN/JuliaRL_BasicDQN_CartPole.jl
+++ b/docs/experiments/experiments/DQN/JuliaRL_BasicDQN_CartPole.jl
@@ -57,10 +57,23 @@ function RL.Experiment(
 end
 
 #+ tangle=false
-using Plots
-ex = E`JuliaRL_BasicDQN_CartPole`
-run(ex)
-plot(ex.hook.rewards)
-savefig("assets/JuliaRL_BasicDQN_CartPole.png") #hide
+
+# Now let's run this experiment and see the rewards:
+
+# ```julia
+# using Plots
+# ex = E`JuliaRL_BasicDQN_CartPole`
+# run(ex)
+# plot(ex.hook.rewards)
+# ```
+
+#src FIXME: run(ex) errors if passed to Documenter, so wrap with julia annoation, and
+#src        only run it with DemoCards
+using Plots #src
+ex = E`JuliaRL_BasicDQN_CartPole` #src
+run(ex) #src
+plot(ex.hook.rewards) #src
+isdir("assets") || mkdir("assets") #src
+savefig("assets/JuliaRL_BasicDQN_CartPole.png") #src
 
 # ![](assets/JuliaRL_BasicDQN_CartPole.png)

--- a/docs/experiments/experiments/DQN/JuliaRL_BasicDQN_EmptyRoom.jl
+++ b/docs/experiments/experiments/DQN/JuliaRL_BasicDQN_EmptyRoom.jl
@@ -70,10 +70,23 @@ function RL.Experiment(
 end
 
 #+ tangle=false
-using Plots
-abc = E`JuliaRL_BasicDQN_EmptyRoom`
-run(abc)
-plot(abc.hook.rewards)
-savefig("assets/JuliaRL_BasicDQN_EmptyRoom.png") #hide
+
+# Now let's run this experiment and see the rewards:
+
+# ```julia
+# using Plots
+# ex = E`JuliaRL_BasicDQN_EmptyRoom`
+# run(ex)
+# plot(ex.hook.rewards)
+# ```
+
+#src FIXME: run(ex) errors if passed to Documenter, so wrap with julia annoation, and
+#src        only run it with DemoCards
+using Plots #src
+ex = E`JuliaRL_BasicDQN_EmptyRoom` #src
+run(ex) #src
+plot(ex.hook.rewards) #src
+isdir("assets") || mkdir("assets") #src
+savefig("assets/JuliaRL_BasicDQN_EmptyRoom.png") #src
 
 # ![](assets/JuliaRL_BasicDQN_EmptyRoom.png)


### PR DESCRIPTION
- It seems that Documenter is complaining that `run(ex)` errors, so I work it around by wrapping it as a non-executed version `julia`.
- It seems that `Experiment(..., "")` with empty description will still print a new line, which I think can be improved.

preview:

<img src="https://user-images.githubusercontent.com/8684355/119261733-43051200-bc0b-11eb-88c8-79dad13fb0c1.png" alt="demo" width="500">
