### PR TITLE
Make SAC policy use internal rng

### DIFF
--- a/src/ReinforcementLearningZoo/src/algorithms/policy_gradient/sac.jl
+++ b/src/ReinforcementLearningZoo/src/algorithms/policy_gradient/sac.jl
@@ -120,7 +120,7 @@ function (p::SACPolicy)(env)
         s = state(env)
         s = Flux.unsqueeze(s, ndims(s) + 1)
         # trainmode:
-        action = dropdims(p.policy.model(s; is_sampling=true, is_return_log_prob=true)[1], dims=2) # Single action vec, drop second dim
+        action = dropdims(p.policy.model(p.rng, s; is_sampling=true, is_return_log_prob=true)[1], dims=2) # Single action vec, drop second dim
 
         # testmode:
         # if testing dont sample an action, but act deterministically by
@@ -146,7 +146,7 @@ function RLBase.update!(p::SACPolicy, batch::NamedTuple{SARTS})
 
     γ, τ, α = p.γ, p.τ, p.α
 
-    a′, log_π = p.policy.model(s′; is_sampling=true, is_return_log_prob=true)
+    a′, log_π = p.policy.model(p.rng, s′; is_sampling=true, is_return_log_prob=true)
     q′_input = vcat(s′, a′)
     q′ = min.(p.target_qnetwork1(q′_input), p.target_qnetwork2(q′_input))
 
@@ -168,7 +168,7 @@ function RLBase.update!(p::SACPolicy, batch::NamedTuple{SARTS})
 
     # Train Policy
     p_grad = gradient(Flux.params(p.policy)) do
-        a, log_π = p.policy.model(s; is_sampling=true, is_return_log_prob=true)
+        a, log_π = p.policy.model(p.rng, s; is_sampling=true, is_return_log_prob=true)
         q_input = vcat(s, a)
         q = min.(p.qnetwork1(q_input), p.qnetwork2(q_input))
         reward = mean(q)


### PR DESCRIPTION
Had some reproducibility issues in my experiments and found that SAC was currently not using its internal rng to sample the actions.