### PR TITLE
try to fix bugs of ActionTransformedEnv

### DIFF
--- a/src/ReinforcementLearningCore/src/policies/agents/agent.jl
+++ b/src/ReinforcementLearningCore/src/policies/agents/agent.jl
@@ -137,11 +137,11 @@ function RLBase.update!(
     # the global rng. In theory it shouldn't affect the performance of specific
     # algorithm.
     # TODO: how to inject a local rng here to avoid polluting the global rng
-    action = rand(action_space(env))
 
     s = policy isa NamedPolicy ? state(env, nameof(policy)) : state(env)
+    a = policy isa NamedPolicy ? rand(action_space(env, nameof(policy))) : rand(action_space(env))
     push!(trajectory[:state], s)
-    push!(trajectory[:action], action)
+    push!(trajectory[:action], a)
     if haskey(trajectory, :legal_actions_mask)
         lasm =
             policy isa NamedPolicy ? legal_action_space_mask(env, nameof(policy)) :

--- a/src/ReinforcementLearningEnvironments/src/environments/wrappers/ActionTransformedEnv.jl
+++ b/src/ReinforcementLearningEnvironments/src/environments/wrappers/ActionTransformedEnv.jl
@@ -17,10 +17,10 @@ ActionTransformedEnv(env; action_mapping = identity, action_space_mapping = iden
     ActionTransformedEnv(env, action_mapping, action_space_mapping)
 
 RLBase.action_space(env::ActionTransformedEnv, args...) =
-    env.action_space_mapping(action_space(env.env), args...)
+    env.action_space_mapping(action_space(env.env, args...))
 
 RLBase.legal_action_space(env::ActionTransformedEnv, args...) =
-    env.action_space_mapping(legal_action_space(env.env), args...)
+    env.action_space_mapping(legal_action_space(env.env, args...))
 
 (env::ActionTransformedEnv)(action, args...; kwargs...) =
     env.env(env.action_mapping(action), args...; kwargs...)


### PR DESCRIPTION
When I want to get the action space of the player 1 with an `ActionTransformedEnv,` it will raise errors like the following:

```Julia
julia> using ReinforcementLearning
julia> env = KuhnPokerEnv();
julia> wrapped_env = ActionTransformedEnv(env);
julia> action_space(wrapped_env, 1)
ERROR: MethodError: no method matching identity(::Base.OneTo{Int64}, ::Int64)
```

Maybe we should move `args...` into the `action_space` function...