### PR TITLE
add maxdepth kwarg to remove print_tree() deprecation warning

### DIFF
--- a/src/ReinforcementLearningCore/src/core/experiment.jl
+++ b/src/ReinforcementLearningCore/src/core/experiment.jl
@@ -24,7 +24,7 @@ end
 
 function Base.show(io::IO, x::Experiment)
     display(Markdown.parse(x.description))
-    AbstractTrees.print_tree(io, StructTree(x), get(io, :max_depth, 10))
+    AbstractTrees.print_tree(io, StructTree(x), maxdepth=get(io, :max_depth, 10))
 end
 
 macro experiment_cmd(s)

--- a/src/ReinforcementLearningCore/src/extensions/ReinforcementLearningBase.jl
+++ b/src/ReinforcementLearningCore/src/extensions/ReinforcementLearningBase.jl
@@ -1,6 +1,6 @@
 using AbstractTrees
 
 Base.show(io::IO, p::AbstractPolicy) =
-    AbstractTrees.print_tree(io, StructTree(p), get(io, :max_depth, 10))
+    AbstractTrees.print_tree(io, StructTree(p), maxdepth=get(io, :max_depth, 10))
 
 is_expand(::AbstractEnv) = false

--- a/src/ReinforcementLearningCore/src/policies/q_based_policies/learners/abstract_learner.jl
+++ b/src/ReinforcementLearningCore/src/policies/q_based_policies/learners/abstract_learner.jl
@@ -17,7 +17,7 @@ function (learner::AbstractLearner)(env) end
 function RLBase.priority(p::AbstractLearner, experience) end
 
 Base.show(io::IO, p::AbstractLearner) =
-    AbstractTrees.print_tree(io, StructTree(p), get(io, :max_depth, 10))
+    AbstractTrees.print_tree(io, StructTree(p), maxdepth=get(io, :max_depth, 10))
 
 function RLBase.update!(
     L::AbstractLearner,


### PR DESCRIPTION
This is to remove annoying print_tree() deprecation warning.