### PR TITLE
More efficient float32 randn

### DIFF
--- a/src/ReinforcementLearningCore/src/policies/q_based_policies/learners/approximators/neural_network_approximator.jl
+++ b/src/ReinforcementLearningCore/src/policies/q_based_policies/learners/approximators/neural_network_approximator.jl
@@ -179,7 +179,7 @@ end
 
 function decode(rng::AbstractRNG, model::VAE, state, z=nothing; is_normalize::Bool=true)
     if z === nothing
-        z = clamp.(randn(rng, Float32, (model.latent_dims, size(state)[2:ndims(state)]...)), -0.5f0, 0.5f0)
+        z = clamp.(randn(rng, Float32, (model.latent_dims, size(state)[2:end]...)), -0.5f0, 0.5f0)
     end
     a = model.decoder(vcat(state, z))
     if is_normalize

--- a/src/ReinforcementLearningCore/src/policies/q_based_policies/learners/approximators/neural_network_approximator.jl
+++ b/src/ReinforcementLearningCore/src/policies/q_based_policies/learners/approximators/neural_network_approximator.jl
@@ -98,7 +98,7 @@ function (model::GaussianNetwork)(rng::AbstractRNG, state; is_sampling::Bool=fal
     logσ = clamp.(raw_logσ, log(model.min_σ), log(model.max_σ))
     if is_sampling
         σ = exp.(logσ)
-        z = μ .+ σ .* send_to_device(device(model), Float32.(randn(rng, size(μ))))
+        z = μ .+ σ .* send_to_device(device(model), randn(rng, Float32, size(μ)))
         if is_return_log_prob
             logp_π = sum(normlogpdf(μ, σ, z) .- (2.0f0 .* (log(2.0f0) .- z .- softplus.(-2.0f0 .* z))), dims = 1)
             return tanh.(z), logp_π
@@ -179,7 +179,7 @@ end
 
 function decode(rng::AbstractRNG, model::VAE, state, z=nothing; is_normalize::Bool=true)
     if z === nothing
-        z = clamp.(Float32.(rand(rng, Normal(0, 1), (model.latent_dims, size(state)[2:ndims(state)]...))), -0.5f0, 0.5f0)
+        z = clamp.(randn(rng, Float32, (model.latent_dims, size(state)[2:ndims(state)]...)), -0.5f0, 0.5f0)
     end
     a = model.decoder(vcat(state, z))
     if is_normalize


### PR DESCRIPTION
Found this when looking through PR #497 but not until after it was merged so started this separate one. 

The thing is that the numbers were generated and then converted, and since there exists a `randn(rng, Float32, size)` signature I assumed that would be more efficient.

So there were actually two different calls used in the code, here `f1` and `f2`, and `f3` is the one suggested in this PR. Testing them on small sizes it is almost twice as fast with `f3`, but when reaching larger sizes it actually isn't, and I have no clue why. I think I still prefer this way since it feels like how julia wants it to be done, but if there are a few action dimension and some larger batches are used it could be a loss in speed so maybe it should be considered. Maybe not the most important thing since this will probably still be a small part compared to any training, but thought I would put it up here as a draft for now if anyone had opinions.

I will try to check upstream if this behaviour can be explained.

I also switched a slice which used `ndims` to using `end` since it seemed like the common way to do it, I hope there wasn't any reason behind it.

```julia
julia> using Random, BenchmarkTools, Distributions

julia> rng = MersenneTwister()
MersenneTwister(0x838ac939fd0608a428a6db0e5f1b7232)

julia> f1(rng, n) = Float32.(randn(rng, n))
f1 (generic function with 2 methods)

julia> f2(rng, n) = Float32.(rand(rng, Normal(0, 1), n))
f2 (generic function with 2 methods)

julia> f3(rng, n) = randn(rng, Float32, n)
f3 (generic function with 2 methods)

julia> @benchmark f1($rng, 10)
BenchmarkTools.Trial: 10000 samples with 925 evaluations.
 Range (min … max):  104.898 ns … 937.498 ns  ┊ GC (min … max): 0.00% … 75.44%
 Time  (median):     113.588 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   120.013 ns ±  52.940 ns  ┊ GC (mean ± σ):  3.11% ±  6.39%

   ▁▅█▁                                                          
  ▅████▅▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▁▁▁▂▂▁▂▂▁▁▁▂▁▁▁▁▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▂
  105 ns           Histogram: frequency by time          272 ns <

 Memory estimate: 288 bytes, allocs estimate: 2.

julia> @benchmark f2($rng, 10)
BenchmarkTools.Trial: 10000 samples with 927 evaluations.
 Range (min … max):  101.969 ns … 866.526 ns  ┊ GC (min … max): 0.00% … 79.32%
 Time  (median):     110.975 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   118.787 ns ±  54.236 ns  ┊ GC (mean ± σ):  3.23% ±  6.45%

  ▂▅██▇▅▃▂▂▁                                                    ▂
  ██████████▇█▇▅▆▅▆▄▄▅▄▅▃▃▄▄▄▁▁▁▁▃▃▃▃▄▅▄▆▅▅▆▄▅▆▇▆▆▆▆▇▄▄▄▆▅▅▄▅▅▅ █
  102 ns        Histogram: log(frequency) by time        271 ns <

 Memory estimate: 288 bytes, allocs estimate: 2.

julia> @benchmark f3($rng, 10)
BenchmarkTools.Trial: 10000 samples with 973 evaluations.
 Range (min … max):  66.963 ns … 712.664 ns  ┊ GC (min … max): 0.00% … 87.88%
 Time  (median):     72.424 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   76.466 ns ±  32.591 ns  ┊ GC (mean ± σ):  2.03% ±  4.57%

  ▁▅███▆▅▃▂                                                    ▂
  ██████████▇▆█▇▆▄▅▄▄▅▄▄▁▄▃▃▃▁▁▁▃▃▃▁▁▄▇▆▇▆▇██▅▇▇▇▅▇▆▆▆▆▆▆▆▅▅▅▆ █
  67 ns         Histogram: log(frequency) by time       153 ns <

 Memory estimate: 128 bytes, allocs estimate: 1.

julia> @benchmark f1($rng, 1000)
BenchmarkTools.Trial: 10000 samples with 8 evaluations.
 Range (min … max):  3.704 μs … 177.284 μs  ┊ GC (min … max): 0.00% … 89.22%
 Time  (median):     4.130 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.522 μs ±   6.154 μs  ┊ GC (mean ± σ):  5.75% ±  4.11%

        ▁▅▇█▆▅▅▃▂                                              
  ▁▁▂▃▄▇██████████▇▅▅▄▃▃▃▃▂▃▃▃▃▂▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  3.7 μs          Histogram: frequency by time        5.81 μs <

 Memory estimate: 12.00 KiB, allocs estimate: 2.

julia> @benchmark f2($rng, 1000)
BenchmarkTools.Trial: 10000 samples with 7 evaluations.
 Range (min … max):  4.277 μs … 170.262 μs  ┊ GC (min … max): 0.00% … 89.86%
 Time  (median):     4.793 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.164 μs ±   6.341 μs  ┊ GC (mean ± σ):  4.85% ±  3.83%

        ▃▅██▇▅▄▄▃▃▁                                            
  ▁▁▂▂▅▇███████████▇▅▅▄▃▃▃▃▂▂▂▂▂▂▂▁▁▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  4.28 μs         Histogram: frequency by time        6.79 μs <

 Memory estimate: 12.00 KiB, allocs estimate: 2.

julia> @benchmark f3($rng, 1000)
BenchmarkTools.Trial: 10000 samples with 8 evaluations.
 Range (min … max):  3.734 μs … 199.280 μs  ┊ GC (min … max): 0.00% … 91.09%
 Time  (median):     4.071 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.301 μs ±   5.010 μs  ┊ GC (mean ± σ):  2.85% ±  2.41%

     ▃▇▇█▇▆▆▆▅▃▂                                               
  ▁▃▆████████████▇▅▄▃▃▂▂▂▂▂▂▂▂▂▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  3.73 μs         Histogram: frequency by time        5.84 μs <

 Memory estimate: 4.06 KiB, allocs estimate: 1.

julia> @benchmark f1($rng, 10000)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  32.158 μs … 696.341 μs  ┊ GC (min … max): 0.00% … 93.02%
 Time  (median):     35.737 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   39.041 μs ±  26.132 μs  ┊ GC (mean ± σ):  3.15% ±  4.58%

   ▄▇██▇▅▄▄▃▄▃▃▂▂▂▂▂▁▂▁▁                                       ▂
  ████████████████████████▇▇▇▇▇▆▆▆▆▅▇▇▇▆▆▄▅▄▅▃▄▃▅▅▄▅▃▃▄▄▁▃▄▆▆▆ █
  32.2 μs       Histogram: log(frequency) by time      80.4 μs <

 Memory estimate: 117.34 KiB, allocs estimate: 4.

julia> @benchmark f2($rng, 10000)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  38.835 μs … 610.942 μs  ┊ GC (min … max): 0.00% … 82.91%
 Time  (median):     41.852 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   45.045 μs ±  25.628 μs  ┊ GC (mean ± σ):  2.65% ±  4.47%

  ▃▇█▇▇▆▅▄▃▂▂▂▂▁▂▂▁▁▁                                          ▂
  █████████████████████▇▆▆▅▆▅▅▅▄▅▅▃▁▁▄▁▁▃▃▃▃▁▁▃▁▁▃▁▄▁▃▄▆▆▆▅▇▇▆ █
  38.8 μs       Histogram: log(frequency) by time        96 μs <

 Memory estimate: 117.34 KiB, allocs estimate: 4.

julia> @benchmark f3($rng, 10000)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  34.813 μs … 686.549 μs  ┊ GC (min … max): 0.00% … 90.91%
 Time  (median):     36.819 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   39.285 μs ±  17.336 μs  ┊ GC (mean ± σ):  1.14% ±  2.59%

   ▄▇██▇▆▄▄▄▃▃▃▂▁▁                              ▁▁▁▁           ▂
  ▆███████████████████▇▇█▇▇▇▇▇▆▆▆▆▆▆▆▇▆▇▆▆▇█▇▇████████▇▇▇▆▆▆▆▆ █
  34.8 μs       Histogram: log(frequency) by time      59.9 μs <

 Memory estimate: 39.14 KiB, allocs estimate: 2.

```