### PR TITLE
Fix dispatch for is_discrete_space

### DIFF
--- a/src/ReinforcementLearningEnvironments/src/converters.jl
+++ b/src/ReinforcementLearningEnvironments/src/converters.jl
@@ -2,11 +2,11 @@ export is_discrete_space, discrete2standard_discrete
 
 is_discrete_space(x) = is_discrete_space(typeof(x))
 
-is_discrete_space(::Type{AbstractVector}) = true
-is_discrete_space(::Type{Tuple}) = true
-is_discrete_space(::Type{NamedTuple}) = true
+is_discrete_space(::Type{<:AbstractVector}) = true
+is_discrete_space(::Type{<:Tuple}) = true
+is_discrete_space(::Type{<:NamedTuple}) = true
 
-is_discrete_space(::Type{Space}) = false
+is_discrete_space(::Type{<:Space}) = false
 
 """
     discrete2standard_discrete(env)


### PR DESCRIPTION
`is_discrete_space(1:5)` was not working for me (when I was trying to convert an environment with `discrete2standard_discrete`).

The reason is that 
`typeof([1,2,3]) isa Type{AbstractVector} == false`
`typeof([1,2,3]) isa Type{<:AbstractVector} == true`

Or from the julia manual: https://docs.julialang.org/en/v1/manual/types/#man-typet-type

> `isa(A, Type{B})` is true if and only if A and B are the same object and that object is a type 



PR Checklist

- [ ] Update NEWS.md?