### PR TITLE
fixed findmax unconsistency

### DIFF
--- a/src/ReinforcementLearningCore/src/utils/base.jl
+++ b/src/ReinforcementLearningCore/src/utils/base.jl
@@ -149,7 +149,7 @@ end
 # _rf_findmax((fm, m), (fx, x)) = isless(fm, fx) ? (fx, x) : (fm, m)
 
 # !!! type piracy
-Base.findmax(A::AbstractVector, mask::AbstractVector{Bool}) = findmax(map( x -> !mask[x[1]] ? -Inf : x[2], enumerate(A)))
+Base.findmax(A::AbstractVector{T}, mask::AbstractVector{Bool}) where T = findmax(ifelse.(mask, A, typemin(T)))
 
 
 const VectorOrMatrix = Union{AbstractMatrix,AbstractVector}


### PR DESCRIPTION
Following the discussion of the Issue #520, this is my proposition of solution for the bug on the `Base.findmax` function due to the recent changes on [Julia Core package](https://github.com/JuliaLang/julia/pull/41076/files ) and [JuliaLang/Compat.jl#748](https://github.com/JuliaLang/Compat.jl/pull/748). (The find_all_max is not to be impacted by the recent changes)

Originally, depending if the explorer with return the greedy choice or a random choice, the output was respectively :
- _for the greedy choice_  : the index of the selected value in the **subset** of the authorized values, instead of the original set of values.
-  _for the random choice_ : the index of the selected value in the original set of values.