### PR TITLE
Added a continuous option for CartPoleEnv

### DIFF
--- a/src/ReinforcementLearningEnvironments/src/environments/examples/CartPoleEnv.jl
+++ b/src/ReinforcementLearningEnvironments/src/environments/examples/CartPoleEnv.jl
@@ -19,30 +19,7 @@ Base.show(io::IO, params::CartPoleEnvParams) = print(
     join(["$p=$(getfield(params, p))" for p in fieldnames(CartPoleEnvParams)], ","),
 )
 
-mutable struct CartPoleEnv{T,R<:AbstractRNG} <: AbstractEnv
-    params::CartPoleEnvParams{T}
-    state::Array{T,1}
-    action::Int
-    done::Bool
-    t::Int
-    rng::R
-end
-
-"""
-    CartPoleEnv(;kwargs...)
-
-# Keyword arguments
-- `T = Float64`
-- `gravity = T(9.8)`
-- `masscart = T(1.0)`
-- `masspole = T(0.1)`
-- `halflength = T(0.5)`
-- `forcemag = T(10.0)`
-- `max_steps = 200`
-- 'dt = 0.02'
-- `rng = Random.GLOBAL_RNG`
-"""
-function CartPoleEnv(;
+function CartPoleEnvParams(;
     T = Float64,
     gravity = 9.8,
     masscart = 1.0,
@@ -51,9 +28,10 @@ function CartPoleEnv(;
     forcemag = 10.0,
     max_steps = 200,
     dt = 0.02,
-    rng = Random.GLOBAL_RNG,
+    thetathreshold = 12.0,
+    xthreshold = 2.4,
 )
-    params = CartPoleEnvParams{T}(
+    CartPoleEnvParams{T}(
         gravity,
         masscart,
         masspole,
@@ -62,45 +40,102 @@ function CartPoleEnv(;
         masspole * halflength,
         forcemag,
         dt,
-        2 * 12 * π / 360,
-        2.4,
+        thetathreshold * π / 180,
+        xthreshold,
         max_steps,
     )
-    high = cp = CartPoleEnv(params, zeros(T, 4), 2, false, 0, rng)
-    reset!(cp)
-    cp
 end
 
-CartPoleEnv{T}(; kwargs...) where {T} = CartPoleEnv(; T = T, kwargs...)
+    mutable struct CartPoleEnv{A,T,ACT,R<:AbstractRNG} <: AbstractEnv
+        params::CartPoleEnvParams{T}
+        action_space::A
+        observation_space::Space{Vector{ClosedInterval{T}}}
+        state::Vector{T}
+        action::ACT
+        done::Bool
+        t::Int
+        rng::R
+    end
 
-function RLBase.reset!(env::CartPoleEnv{T}) where {T<:Number}
+"""
+    CartPoleEnv(;kwargs...)
+
+# Keyword arguments
+- `T = Float64`
+- `continuous = false`
+- `rng = Random.GLOBAL_RNG`
+- `gravity = T(9.8)`
+- `masscart = T(1.0)`
+- `masspole = T(0.1)`
+- `halflength = T(0.5)`
+- `forcemag = T(10.0)`
+- `max_steps = 200`
+- 'dt = 0.02'
+- `thetathreshold = 12.0 # degrees`
+- `xthreshold` = 2.4``
+"""
+function CartPoleEnv(;
+    T = Float64,
+    continuous = false,
+    rng = Random.GLOBAL_RNG,
+    kwargs...,
+)
+    params = CartPoleEnvParams(kwargs...)
+    action_space = continuous ? ClosedInterval{T}(-1.0, 1.0) : Base.OneTo(2)
+    state_space = Space(
+        ClosedInterval{T}[
+            (-2*params.xthreshold)..(2*params.xthreshold),
+            -1e38..1e38,
+            (-2*params.thetathreshold)..(2*params.thetathreshold),
+            -1e38..1e38,
+        ],
+    )
+    env = CartPoleEnv(
+        params, 
+        action_space,
+        state_space,
+        zeros(T, 4),
+        rand(action_space),
+        false,
+        0,
+        rng,
+    )
+    reset!(env)
+    env
+end
+
+CartPoleEnv{T}(; kwargs...) where {T} = CartPoleEnv(T=T, kwargs...)
+
+Random.seed!(env::CartPoleEnv, seed) = Random.seed!(env.rng, seed)
+RLBase.action_space(env::CartPoleEnv) = env.action_space
+RLBase.state_space(env::CartPoleEnv) = env.observation_space
+RLBase.reward(env::CartPoleEnv{A,T}) where {A,T} = env.done ? zero(T) : one(T)
+RLBase.is_terminated(env::CartPoleEnv) = env.done
+RLBase.state(env::CartPoleEnv) = env.state
+
+function RLBase.reset!(env::CartPoleEnv{A,T}) where {A,T}
     env.state[:] = T(0.1) * rand(env.rng, T, 4) .- T(0.05)
     env.t = 0
-    env.action = 2
+    env.action = rand(env.action_space)
     env.done = false
     nothing
 end
 
-RLBase.action_space(env::CartPoleEnv) = Base.OneTo(2)
-
-RLBase.state_space(env::CartPoleEnv{T}) where {T} = Space(
-    ClosedInterval{T}[
-        (-2*env.params.xthreshold)..(2*env.params.xthreshold),
-        -1e38..1e38,
-        (-2*env.params.thetathreshold)..(2*env.params.thetathreshold),
-        -1e38..1e38,
-    ],
-)
-
-RLBase.reward(env::CartPoleEnv{T}) where {T} = env.done ? zero(T) : one(T)
-RLBase.is_terminated(env::CartPoleEnv) = env.done
-RLBase.state(env::CartPoleEnv) = env.state
-
-function (env::CartPoleEnv)(a)
-    @assert a in (1, 2)
+function (env::CartPoleEnv{<:ClosedInterval})(a::AbstractFloat)
+    @assert a in env.action_space
     env.action = a
+    _step!(env, a)
+end
+
+function (env::CartPoleEnv{<:Base.OneTo{Int}})(a::Int)
+    @assert a in env.action_space
+    env.action = a
+    _step!(env, a == 2 ? 1 : -1)
+end
+
+function _step!(env::CartPoleEnv, a)
     env.t += 1
-    force = a == 2 ? env.params.forcemag : -env.params.forcemag
+    force = a * env.params.forcemag
     x, xdot, theta, thetadot = env.state
     costheta = cos(theta)
     sintheta = sin(theta)
@@ -121,5 +156,3 @@ function (env::CartPoleEnv)(a)
         env.t > env.params.max_steps
     nothing
 end
-
-Random.seed!(env::CartPoleEnv, seed) = Random.seed!(env.rng, seed)

--- a/src/ReinforcementLearningEnvironments/src/environments/examples/CartPoleEnv.jl
+++ b/src/ReinforcementLearningEnvironments/src/environments/examples/CartPoleEnv.jl
@@ -116,7 +116,7 @@ RLBase.state(env::CartPoleEnv) = env.state
 function RLBase.reset!(env::CartPoleEnv{A,T}) where {A,T}
     env.state[:] = T(0.1) * rand(env.rng, T, 4) .- T(0.05)
     env.t = 0
-    env.action = rand(env.action_space)
+    env.action = rand(env.rng, env.action_space)
     env.done = false
     nothing
 end

--- a/src/ReinforcementLearningEnvironments/src/environments/examples/MountainCarEnv.jl
+++ b/src/ReinforcementLearningEnvironments/src/environments/examples/MountainCarEnv.jl
@@ -11,16 +11,21 @@ struct MountainCarEnvParams{T}
     max_steps::Int
 end
 
+Base.show(io::IO, params::MountainCarEnvParams) = print(
+    io,
+    join(["$p=$(getfield(params, p))" for p in fieldnames(MountainCarEnvParams)], ","),
+)
+
 function MountainCarEnvParams(;
     T = Float64,
     min_pos = -1.2,
     max_pos = 0.6,
     max_speed = 0.07,
     goal_pos = 0.5,
-    max_steps = 200,
     goal_velocity = 0.0,
     power = 0.001,
     gravity = 0.0025,
+    max_steps = 200,
 )
     MountainCarEnvParams{T}(
         min_pos,
@@ -49,7 +54,6 @@ end
     MountainCarEnv(;kwargs...)
 
 # Keyword arguments
-
 - `T = Float64`
 - `continuous = false`
 - `rng = Random.GLOBAL_RNG`
@@ -135,3 +139,4 @@ function _step!(env::MountainCarEnv, force)
     env.state[2] = v
     nothing
 end
+

--- a/src/ReinforcementLearningEnvironments/src/plots.jl
+++ b/src/ReinforcementLearningEnvironments/src/plots.jl
@@ -1,11 +1,11 @@
-import .Plots.closeall
 import .Plots.gui
 import .Plots.plot
 import .Plots.plot!
+import .Plots.annotate!
 
 function plot(env::CartPoleEnv; kwargs...)
-    s, a, d = env.state, env.action, env.done
-    x, xdot, theta, thetadot = s
+    a, d = env.action, env.done
+    x, xdot, theta, thetadot = env.state
     l = 2 * env.params.halflength
     xthreshold = env.params.xthreshold
     # set the frame
@@ -24,18 +24,25 @@ function plot(env::CartPoleEnv; kwargs...)
         linewidth=3,
     )
     # plot the arrow
-    plot!([x + (a == 1) - 0.5, x + 1.4 * (a == 1)-0.7], [ -.025, -.025];
+    if isa(action_space(env), Base.OneTo)
+        a = a == 2 ? 1 : -1
+    end
+    plot!([x + sign(a)*0.5, x + sign(a)*0.7], [ -.025, -.025];
         linewidth=3,
         arrow=true,
-        color=2,
+        color=:black,
     )
-    # if done plot pink circle in top right
+    # if done plot pink circle in top right (green in t > max steps)
     if d
+        color = :pink
+        if env.t > env.params.max_steps
+            color = :green
+        end
         plot!([xthreshold - 0.2], [l];
             marker=:circle,
             markersize=20,
             markerstrokewidth=0.,
-            color=:pink,
+            color=color,
         )
     end
     
@@ -51,7 +58,7 @@ rotate(xs, ys, θ) = xs * cos(θ) - ys * sin(θ), ys * cos(θ) + xs * sin(θ)
 translate(xs, ys, t) = xs .+ t[1], ys .+ t[2]
 
 function plot(env::MountainCarEnv; kwargs...)
-    s = env.state
+    x, v = env.state
     d = env.done
 
     plot(
@@ -66,7 +73,6 @@ function plot(env::MountainCarEnv; kwargs...)
     plot!(xs, ys)
 
     # plot the car
-    x = s[1]
     θ = cos(3 * x)
     carwidth = 0.05
     carheight = carwidth / 2
@@ -78,16 +84,26 @@ function plot(env::MountainCarEnv; kwargs...)
     xs, ys = translate(xs, ys, [x, height(x)])
     plot!(xs, ys; seriestype=:shape)
 
-    # if done plot pink circle in top right
-    if d
-      plot!([env.params.max_pos - 0.2], [height(env.params.max_pos) + 0.1];
+     # if done plot pink circle in top right (green if reached the goal)
+     if d
+        color = :pink
+        if x >= env.params.goal_pos && v >= env.params.goal_velocity
+            color = :green
+        end
+
+        plot!([env.params.max_pos+0.1], [height(env.params.max_pos)+0.1];
             marker=:circle,
             markersize=20,
             markerstrokewidth=0.,
-            color=:pink,
+            color=color,
         )
     end
 
+    # Add annotation of action on the bottom
+    pos_x = (env.params.max_pos + env.params.min_pos) / 2
+    pos_y = -0.05
+    a = round(env.action, digits=2)
+    annotate!(pos_x, pos_y, "Action: $a", :black)
     p = plot!(;kwargs...)
     gui(p)
     p


### PR DESCRIPTION
Extended the traditional CartPoleEnv to have a continuous option. Also restructured it to be more aligned with the MountainCarEnv.

Edit: Updated the plots for CartPoleEnv and MountionCarEnv. Small changes overall. 