### PR TITLE
Remove unneeded method

### DIFF
--- a/src/ReinforcementLearningZoo/src/algorithms/tabular/monte_carlo_learner.jl
+++ b/src/ReinforcementLearningZoo/src/algorithms/tabular/monte_carlo_learner.jl
@@ -61,13 +61,6 @@ function RLBase.update!(
     L::MonteCarloLearner,
     t::AbstractTrajectory,
     e::AbstractEnv,
-    s::PreActStage,
-) end
-
-function RLBase.update!(
-    L::MonteCarloLearner,
-    t::AbstractTrajectory,
-    e::AbstractEnv,
     s::PostEpisodeStage,
 )
     update!(L, t)


### PR DESCRIPTION
Since MonteCarloLearner is an AbstractLearner, this empty method is not needed (default behavior of AbstractLearner).
See here:
https://github.com/JuliaReinforcementLearning/ReinforcementLearning.jl/blob/8c0a317e35921c7a989597f87f570f58578fb1cf/src/ReinforcementLearningCore/src/policies/q_based_policies/learners/abstract_learner.jl#L22-L27