### PR TITLE
Fix documentation for environments

### DIFF
--- a/src/ReinforcementLearningEnvironments/src/environments/3rd_party/AcrobotEnv.jl
+++ b/src/ReinforcementLearningEnvironments/src/environments/3rd_party/AcrobotEnv.jl
@@ -1,5 +1,6 @@
 """
-AcrobotEnv(;kwargs...)
+    AcrobotEnv(;kwargs...)
+
 # Keyword arguments
 - `T = Float64`
 - `link_length_a = T(1.)`

--- a/src/ReinforcementLearningEnvironments/src/environments/examples/CartPoleEnv.jl
+++ b/src/ReinforcementLearningEnvironments/src/environments/examples/CartPoleEnv.jl
@@ -70,9 +70,9 @@ end
 - `halflength = T(0.5)`
 - `forcemag = T(10.0)`
 - `max_steps = 200`
-- 'dt = 0.02'
+- `dt = 0.02`
 - `thetathreshold = 12.0 # degrees`
-- `xthreshold` = 2.4``
+- `xthreshold` = 2.4`
 """
 function CartPoleEnv(;
     T = Float64,

--- a/src/ReinforcementLearningEnvironments/src/environments/examples/KuhnPokerEnv.jl
+++ b/src/ReinforcementLearningEnvironments/src/environments/examples/KuhnPokerEnv.jl
@@ -60,6 +60,11 @@ const KUHN_POKER_REWARD_TABLE = Dict(
     (:K, :Q, :pass, :bet, :bet) => 2,
 )
 
+struct KuhnPokerEnv <: AbstractEnv
+    cards::Vector{Symbol}
+    actions::Vector{Symbol}
+end
+
 """
     KuhnPokerEnv()
 
@@ -72,11 +77,6 @@ Here we demonstrate how to write a typical [`ZERO_SUM`](@ref),
 TODO: add public state for [`SPECTOR`](@ref).
 Ref: https://arxiv.org/abs/1906.11110
 """
-struct KuhnPokerEnv <: AbstractEnv
-    cards::Vector{Symbol}
-    actions::Vector{Symbol}
-end
-
 KuhnPokerEnv() = KuhnPokerEnv(Symbol[], Symbol[])
 
 function RLBase.reset!(env::KuhnPokerEnv)

--- a/src/ReinforcementLearningEnvironments/src/environments/examples/TinyHanabiEnv.jl
+++ b/src/ReinforcementLearningEnvironments/src/environments/examples/TinyHanabiEnv.jl
@@ -31,6 +31,11 @@ struct TinyHanabiEnv <: AbstractEnv
     actions::Vector{Int}
 end
 
+"""
+    TinyHanabiEnv()
+
+See https://arxiv.org/abs/1902.00506.
+"""
 TinyHanabiEnv() = TinyHanabiEnv(TINY_HANABI_REWARD_TABLE, Int[], Int[])
 
 function RLBase.reset!(env::TinyHanabiEnv)


### PR DESCRIPTION
Fix a few issues on the docs page https://juliareinforcementlearning.org/docs/rlenvs/:

1. `AcrobotEnv` was not showing as it was not considered as a valid docstring.
2. Formatting issues with `CartPoleEnv`.
3. The link to `KuhnPokerEnv` was not working as the url for the docstring of a `struct` or `function` is different.
4. The link to `TinyHanabiEnv` was not working as it has not docstring.