### PR TITLE
Default qnetwork initializer

### DIFF
--- a/src/ReinforcementLearningZoo/src/algorithms/policy_gradient/sac.jl
+++ b/src/ReinforcementLearningZoo/src/algorithms/policy_gradient/sac.jl
@@ -64,9 +64,8 @@ function SACPolicy(;
     policy,
     qnetwork1,
     qnetwork2,
-    target_qnetwork1,
-    target_qnetwork2,
-    start_policy,
+    target_qnetwork1 = deepcopy(qnetwork1),
+    target_qnetwork2 = deepcopy(qnetwork2),
     γ = 0.99f0,
     τ = 0.005f0,
     α = 0.2f0,
@@ -78,6 +77,7 @@ function SACPolicy(;
     lr_alpha = 0.003f0,
     action_dims = 0,
     update_step = 0,
+    start_policy = update_step == 0 ? identity : policy,
     rng = Random.GLOBAL_RNG,
 )
     copyto!(qnetwork1, target_qnetwork1)  # force sync

--- a/src/ReinforcementLearningZoo/src/algorithms/policy_gradient/sac.jl
+++ b/src/ReinforcementLearningZoo/src/algorithms/policy_gradient/sac.jl
@@ -38,17 +38,17 @@ end
 - `policy`, used to get action.
 - `qnetwork1`, used to get Q-values.
 - `qnetwork2`, used to get Q-values.
-- `target_qnetwork1`, used to estimate the target Q-values.
-- `target_qnetwork2`, used to estimate the target Q-values.
+- `target_qnetwork1 = deepcopy(qnetwork1)`, used to estimate the target Q-values.
+- `target_qnetwork2 = deepcopy(qnetwork2)`, used to estimate the target Q-values.
 - `start_policy`, 
 - `γ::Float32 = 0.99f0`, reward discount rate.
 - `τ::Float32 = 0.005f0`, the speed at which the target network is updated.
 - `α::Float32 = 0.2f0`, entropy term.
 - `batch_size = 32`,
-- `start_steps = 10000`,
-- `update_after = 1000`,
-- `update_freq = 50`,
-- `automatic_entropy_tuning::Bool = false`, whether to automatically tune the entropy.
+- `start_steps = 10000`, number of steps where start_policy is used to sample actions
+- `update_after = 1000`, number of steps before starting to update policy
+- `update_freq = 50`, number of steps between each update
+- `automatic_entropy_tuning::Bool = true`, whether to automatically tune the entropy.
 - `lr_alpha::Float32 = 0.003f0`, learning rate of tuning entropy.
 - `action_dims = 0`, the dimensionality of the action. if `automatic_entropy_tuning = true`, must enter this parameter.
 - `update_step = 0`,


### PR DESCRIPTION
Hello,

I'm considering using RL.jl to do some research. I'm currently implementing MPO but when I took a look to the implementation of SAC to get a hang of the inner workings of this package, I noticed some docstrings was incomplete. 
Also, when I tried SAC, I found it cumbersome to specify manually the architecture of the target qnetworks even though they are force copied in the constructor anyways. Finally, the possibility of using a warmup policy is nice but if one does not want to, they still have to specify one. So this PR does three things:

1) It defaults the target networks to copies of the qnetworks 
2) It defaults the start_policy to identity if not used and to `policy` if unspecified by the user
3) It adds some additional information in the docstrings.

I'll soon make some other PRs related to MPO but it is not ready yet. 