### PR TITLE
Fixes CircularArrayBuffers dependency

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,6 +1,13 @@
 # This file is machine-generated - editing it directly is not advised
 
+julia_version = "1.7.1"
 manifest_format = "2.0"
+
+[[AbstractFFTs]]
+deps = ["ChainRulesCore", "LinearAlgebra"]
+git-tree-sha1 = "6f1d9bc1c08f9f4a8fa92e3ea3cb50153a1b40d4"
+uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+version = "1.1.0"
 
 [[deps.AbstractFFTs]]
 deps = ["ChainRulesCore", "LinearAlgebra"]
@@ -76,9 +83,10 @@ uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
 version = "0.1.2"
 
 [[deps.CircularArrayBuffers]]
-git-tree-sha1 = "ee633068b56b04b714d060f13bb01b80be8c87d4"
+deps = ["Adapt"]
+git-tree-sha1 = "91f78fb7c90b7efbf46c6e11605237bc745325be"
 uuid = "9de3a189-e0c0-4e15-ba3b-b14b9fb0aec1"
-version = "0.1.5"
+version = "0.1.6"
 
 [[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
@@ -524,7 +532,7 @@ version = "0.9.7"
 deps = ["AbstractTrees", "Adapt", "ArrayInterface", "CUDA", "CircularArrayBuffers", "Compat", "Dates", "Distributions", "ElasticArrays", "FillArrays", "Flux", "Functors", "GPUArrays", "LinearAlgebra", "MacroTools", "Markdown", "ProgressMeter", "Random", "ReinforcementLearningBase", "Setfield", "Statistics", "StatsBase", "UnicodePlots", "Zygote"]
 path = "src/ReinforcementLearningCore"
 uuid = "de1b191a-4ae0-4afa-a27b-92d07f46b2d6"
-version = "0.8.8"
+version = "0.8.9"
 
 [[deps.ReinforcementLearningEnvironments]]
 deps = ["DelimitedFiles", "IntervalSets", "LinearAlgebra", "MacroTools", "Markdown", "Pkg", "Random", "ReinforcementLearningBase", "Requires", "SparseArrays", "StatsBase"]
@@ -536,7 +544,7 @@ version = "0.6.12"
 deps = ["AbstractTrees", "CUDA", "CircularArrayBuffers", "DataStructures", "Dates", "Distributions", "Flux", "IntervalSets", "LinearAlgebra", "Logging", "MacroTools", "Random", "ReinforcementLearningBase", "ReinforcementLearningCore", "Setfield", "Statistics", "StatsBase", "StructArrays", "Zygote"]
 path = "src/ReinforcementLearningZoo"
 uuid = "d607f57d-ee1e-4ba7-bcf2-7734c1e31854"
-version = "0.5.7"
+version = "0.5.9"
 
 [[deps.Requires]]
 deps = ["UUIDs"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Johanni Brea <jbrea@users.noreply.github.com>", "Jun Tian <tianjun.c
 version = "0.10.0"
 
 [deps]
+CircularArrayBuffers = "9de3a189-e0c0-4e15-ba3b-b14b9fb0aec1"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 ReinforcementLearningBase = "e575027e-6cd6-5018-9292-cdc6200d2b44"
 ReinforcementLearningCore = "de1b191a-4ae0-4afa-a27b-92d07f46b2d6"
@@ -11,6 +12,7 @@ ReinforcementLearningEnvironments = "25e41dd2-4622-11e9-1641-f1adca772921"
 ReinforcementLearningZoo = "d607f57d-ee1e-4ba7-bcf2-7734c1e31854"
 
 [compat]
+CircularArrayBuffers = "< 0.1.7"
 Reexport = "0.2, 1"
 ReinforcementLearningBase = "0.9"
 ReinforcementLearningCore = "0.8"


### PR DESCRIPTION
I encountered a dependency issue when trying to run some experiments that appears to be caused by an update to the `CircularArrayBuffers` package. My project environment had `CircularArrayBuffers@0.1.7` installed and was causing the following error when I tried to run the `JuliaRL_IQN_CartPole` experiment (among others):

```
ERROR: MethodError: no method matching _buffer_frame(::CircularArrayBuffers.CircularVectorBuffer{Float32, Vector{Float32}}, ::Matrix{Int64})

You might have used a 2d row vector where a 1d column vector was required.
Note the difference between 1d column vector [1,2,3] and 2d row vector [1 2 3].
You can convert to a column vector with the vec() function.
Closest candidates are:
  _buffer_frame(::CircularArrayBuffers.CircularArrayBuffer, ::Int64) at ~/.julia/packages/CircularArrayBuffers/FWC6A/src/CircularArrayBuffers.jl:70
  _buffer_frame(::CircularArrayBuffers.CircularArrayBuffer, ::AbstractVector{<:Integer}) at ~/.julia/packages/CircularArrayBuffers/FWC6A/src/CircularArrayBuffers.jl:80
```

The problem resolves itself as soon as I downgrade `CircularArrayBuffers`.

This is probably more like a band-aid than a permanent fix, its probably just a simple change somewhere. But I'm not very familiar with `CircularArrayBuffers` so I thought this fix could be helpful in the meantime.