### PR TITLE
fix test logdetLorU with Float64

### DIFF
--- a/src/ReinforcementLearningCore/test/extensions.jl
+++ b/src/ReinforcementLearningCore/test/extensions.jl
@@ -90,6 +90,6 @@ end
     L = cholesky(Σ).L
     @test logdet(Σ) ≈ RLCore.logdetLorU(L)
     if CUDA.functional()
-        @test logdet(Σ) ≈ RLCore.logdetLorU(cu(L))
+        @test logdet(Σ) ≈ RLCore.logdetLorU(cu(L)) atol = 1f-4
     end
 end

--- a/src/ReinforcementLearningCore/test/extensions.jl
+++ b/src/ReinforcementLearningCore/test/extensions.jl
@@ -85,8 +85,9 @@ end
 end
 
 @testset "logdetLorU" begin
-    L = tril(sqrt.(rand(Float32,5,5) .^2))
-    Σ = L*L'
+    A = rand(5,10)
+    Σ = A*A'
+    L = cholesky(Σ).L
     @test logdet(Σ) ≈ RLCore.logdetLorU(L)
     if CUDA.functional()
         @test logdet(Σ) ≈ RLCore.logdetLorU(cu(L))


### PR DESCRIPTION
This stabilizes the test in two ways: 
- generating Sigma this way ensures a PSD matrix every time
- using Float64 increases the precision to avoid a significant difference. With Float32 I was still getting about 20 fails out of 10000 attempts.
