### PR TITLE
Add Retrace and a QNetwork abstraction

### DIFF
--- a/src/ReinforcementLearningCore/src/policies/agents/trajectories/retrace.jl
+++ b/src/ReinforcementLearningCore/src/policies/agents/trajectories/retrace.jl
@@ -1,0 +1,99 @@
+export RetraceTrajectory
+
+mutable struct RetraceTrajectory{T, S <: AbstractSampler} <: AbstractTrajectory
+    traces::T
+    λ::Float32
+    batch_sampler::S
+end
+
+function RetraceTrajectory(;capacity, batch_size, λ = 0.9f0, nsteps, stack_size = nothing, action_log_prob, rng = Random.GLOBAL_RNG, kwargs...)
+    traj = merge(
+        CircularArrayTrajectory(;
+            capacity = capacity + 1,
+            action_log_prob = action_log_prob,
+        ),
+        CircularArraySARTTrajectory(; capacity = capacity, kwargs...),
+    )
+    sampler = NStepBatchSampler(γ = 1f0, n= nsteps, batch_size = batch_size, stack_size = stack_size, rng = rng)
+    RetraceTrajectory(traj.traces, λ, sampler)
+end
+
+function fetch!(sampler::AbstractSampler, traj::RetraceTrajectory, inds::Vector{Int})
+    n, bz, sz = sampler.γ, sampler.n, sampler.batch_size, sampler.stack_size
+    
+    #with retrace we need all states and actions from inds to inds .+ n 
+    #Am I right to say that cache is not needed here ?
+    s = consecutive_view(traj[:state], inds; n_stack = sz, n_horizon = n) #last dim is batch_size, second to last dim is n
+    a = consecutive_view(traj[:action], inds, n_horizon = n)
+    r = consecutive_view(traj[:reward], inds; n_horizon = n)
+    t = consecutive_view(traj[:terminal], inds; n_horizon = n)
+    logpi = consecutive_view(traj[:action_log_prob], inds; n_horizon = n)
+    
+    k = fill(n, bz) #stores the offset of the terminal/last step of each sample. This will be used to truncate the trajectory when computing the targets. 
+    # make sure that we only consider experiences in current episode
+    for i in 1:bz
+        m = findfirst(view(consecutive_terminals, :, i))
+        if !isnothing(m) #if isnothing, then we use all n sampled steps
+            k[i] = m
+        end
+    end
+
+    batch = NamedTuple{RetraceTraces}((s, a, r, t, logpi))
+
+    if isnothing(sampler.cache)
+        sampler.cache = map(batch) do x
+            convert(Array, x)
+        end
+    else
+        map(sampler.cache, batch) do dest, src
+            copyto!(dest, src)
+        end
+    end
+    return sampler.cache, k
+end
+
+function q_targets(p::AbstractPolicy, traj::RetraceTrajectory, qnetwork::QNetwork, batch, k)
+    states, actions, rewards, terminals, logμs = batch
+    s = send_to_device(device(p), states) 
+    a = send_to_device(device(p), actions)
+    a_t = p(p.rng, s, is_sampling = true)
+    qs_t = qnetwork.target(s, a_t) |> send_to_host #assume qnetwork handles state and action as it is.
+    qs = qnetwork(s, a) |> send_to_host
+    logπs = p(s, a) |> send_to_host
+    ci(logπ, logμ) = traj.λ*min(1, exp(logπ)/exp(logμ))
+    targets = zeros(Float32, size(actions, ndims(actions)))
+    #loop on samples, in principle this can be threaded
+    for (l, (r, t, q, q_t, logπ, logμ, nsteps)) in enumerate(zip(map(tr -> eachslice(tr, dims = ndims(tr)), (rewards, terminals, qs, qs_t, logπs, logμs))..., k)) 
+        δs = @views r[1:end-1] .+ p.γ .* (1 .- t[1:end-1]) .* q_t[2:end] .- q[1:end-1]
+        cs = ci.(logπ, logμ)[1:(nsteps-1)]
+        cs[1] = one(eltype(cs))
+        cumprod!(cs,cs)
+        target = sum(p.γ^(n-1) * cs[n] * δs[n] for n in 1:(nsteps-1))
+        targets[l] = target
+    end
+    return targets
+end
+
+function q_targets(p::AbstractPolicy, traj::RetraceTrajectory, qnetwork::QNetwork, twinqnetwork::QNetwork, batch, k)
+    states, actions, rewards, terminals, logμs = batch
+    s = send_to_device(device(p), states) 
+    a = send_to_device(device(p), actions)
+    a_t = p(p.rng, s, is_sampling = true)
+    q1s_t = qnetwork.target(s, a_t) |> send_to_host
+    q2s_t = twinqnetwork.target(s, a_t) |> send_to_host
+    qs_t = min.(q1s_t, q2s_t)
+    qs = qnetwork(s, a) |> send_to_host
+    logπs = p(s, a) |> send_to_host
+    ci(logπ, logμ) = traj.λ*min(1, exp(logπ)/exp(logμ))
+    targets = zeros(Float32, size(actions, ndims(actions)))
+    #loop on samples, in principle this can be threaded
+    for (l, (r, t, q, q_t, logπ, logμ, nsteps)) in enumerate(zip(map(tr -> eachslice(tr, dims = ndims(tr)), (rewards, terminals, qs, qs_t, logπs, logμs))..., k)) 
+        δs = @views r[1:nsteps-1] .+ p.γ .* (1 .- t[1:nsteps-1]) .* q_t[2:nsteps] .- q[1:nsteps-1]
+        cs = ci.(logπ, logμ)[1:(nsteps-1)]
+        cs[1] = one(eltype(cs))
+        cumprod!(cs,cs)
+        target = sum(p.γ^(n-1) * cs[n] * δs[n] for n in 1:(nsteps-1))
+        targets[l] = target
+    end
+    return targets
+end

--- a/src/ReinforcementLearningCore/src/policies/agents/trajectories/trajectory_extension.jl
+++ b/src/ReinforcementLearningCore/src/policies/agents/trajectories/trajectory_extension.jl
@@ -125,6 +125,8 @@ Base.@kwdef mutable struct NStepBatchSampler{traces} <: AbstractSampler{traces}
     cache::Any = nothing
 end
 
+(s::NStepBatchSampler)(t::AbstractTrajectory) = sample(s.rng, t, s)
+
 # TODO:deprecate
 function StatsBase.sample(rng::AbstractRNG, t::AbstractTrajectory, s::NStepBatchSampler)
     valid_range =

--- a/src/ReinforcementLearningCore/src/policies/q_based_policies/learners/approximators/qnetwork_approximator.jl
+++ b/src/ReinforcementLearningCore/src/policies/q_based_policies/learners/approximators/qnetwork_approximator.jl
@@ -1,0 +1,101 @@
+export AbstractQNetwork, QNetwork, TwinQNetwork
+
+#####################
+#QNetwork
+#####################
+
+abstract type AbstractQNetwork <: AbstractApproximator end
+
+#An AbstractQNetwork is updated given `states, actions` to minimise `mse(targets, Q(states,actions)`
+function update!(qnetwork::AbstractQNetwork, states, actions, targets)
+    τ = qnetwork.τ
+    ps = Flux.params(qnetwork)
+    gs = gradient(ps) do 
+        qs = qnetwork(states, actions) |> vec
+        qnetwork.loss(targets, qs)
+    end
+    if any(x -> !isnothing(x) && any(y -> isnan(y) || isinf(y), x), gs)
+        error("Gradient of QNetwork contains NaN of Inf")
+    end
+    Flux.update!(qnetwork.optimizer, ps, gs)
+
+    if τ != false
+        for (dest, src) in zip(Flux.params(qnetwork.target_qnetwork), Flux.params(qnetwork.qnetwork))
+            dest .= (1 - τ) .* dest .+ τ .* src
+        end
+    end
+end
+
+mutable struct QNetwork{Q <: NeuralNetworkApproximator, T<:Union{Float32, Bool}, F} <: AbstractQNetwork
+    qnetwork::Q
+    target_qnetwork::Q
+    τ::T
+    loss::F
+end
+
+@functor QNetwork
+
+Flux.trainable(q::QNetwork) = (q.qnetwork,)
+
+QNetwork(nn; τ = 0.01f0, target = false, loss = Flux.mse) = QNetwork(nn, target ? deepcopy(nn) : nn, target ? τ : false, loss)
+
+(qnetwork::QNetwork)(states, actions) = qnetwork.qnetwork([states; actions]) #how do we handle image states? Can't concatenate with actions.
+
+#An algorithm that uses a QNetwork can call this function to update it.
+function update_qnetwork!(p::AbstractPolicy, t::AbstractTrajectory)
+    update_qnetwork!(p, t, p.qnetwork)
+end
+#called by the function above, or directly in-algorithm
+function update_qnetwork!(p, t, qnetwork::QNetwork)
+    inds, batch = p.batch_sampler(t) #use the policy's batch_sampler to get a batch
+    y = q_targets(p, t, qnetwork, batch) #compute targets for qnetwork, can be specialised by overloading on a trajectory or policy type
+    update!(qnetwork, batch.state, batch.action, y)
+end
+
+#TD target using the target network. May be overloaded with other trajectories or batch traces
+function q_targets(p::AbstractPolicy, ::AbstractTrajectory, qnetwork::QNetwork, batch::NamedTuple{SARTS})
+    s, a, r, t, s′ = batch.state, batch.action, batch.reward, batch.terminal, batch.next_state
+    a′ = p.policy(p.rng, s′; is_sampling=true, is_return_log_prob=false)
+    q′_input = vcat(s′, a′)
+    q′ = qnetwork.target_qnetwork(q′_input)
+    return r .+ p.γ .* (1 .- t) .* vec(q′)
+end
+
+#####################
+#TwinQNetwork
+#####################
+
+mutable struct TwinQNetwork{Q<:QNetwork} <: AbstractQNetwork
+    qnetwork1::Q 
+    qnetwork2::Q
+end
+
+@functor TwinQNetwork
+
+(qnetwork::TwinQNetwork)(states, actions) = qnetwork.qnetwork1(states, actions) #how do we handle image states? Can't concatenate with actions.
+
+function update_qnetwork!(p, t, twinqnetwork::TwinQNetwork)
+    inds, batch = p.batch_sampler(t)
+    y = q_targets(p, t, twinqnetwork.qnetwork1, twinqnetwork.qnetwork2, batch...)
+    s = batch.state
+    a = batch.action
+    update!(twinqnetwork.qnetwork1, y, s, a)
+
+    inds, batch = p.batch_sampler(t)
+    y = q_targets(p, t, twinqnetwork.qnetwork2, twinqnetwork.qnetwork1, batch...)
+    s = batch.state
+    a = batch.action
+    update!(twinqnetwork.qnetwork2, y, s, a)
+end
+
+#TD target of qnetwork using the twin target networks. May be overloaded with other trajectories or batch traces
+function q_targets(p::AbstractPolicy, ::AbstractTrajectory, qnetwork, twinqnetwork, batch::NamedTuple{SARTS})
+    s, a, r, t, s′ = send_to_device(device(qnetwork.qnetwork), batch)
+    γ = p.γ
+
+    a′ = p.policy(p.rng, s′; is_sampling=true, is_return_log_prob=false)
+    q′_input = vcat(s′, a′)
+    q′ = min.(qnetwork.target_qnetwork(q′_input), twinqnetwork.target_qnetwork(q′_input))
+
+    y = r .+ γ .* (1 .- t) .* vec(q′)
+end


### PR DESCRIPTION
Following our discussion of yesterday at #613, I'm creating this draft PR to show how I went on implementing the Retrace Algorithm. More precisely, I wanted to implement Retrace as a plug-in that can optionally be used by an algorithm (I have #604 in mind mainly) but such a level of abstraction was not implemented yet. So here's my attempt. I assume that this may not be what you have in mind @findmyway but it can be a useful discussion even if this is never merged.

The main idea is that Retrace is just a different way than TD(n) to compute update targets for a QNetwork. So I created a QNetwork abstraction that can be called to be updated given a batch of action, states and targets : `update!(qnetwork::AbstractQNetwork, states, actions, targets)`. 
The main goal here was the introduction of the function `q_targets`, called by `update!`. 

Now, why did I do this? Because then I could implement retrace in way that is reusable by ab algorithm that uses the QNetwork abstraction. `RetraceTrajectory` is an extension of a `Trajectory`, using a new type allows to overload `q_targets`. So an algorithm that uses a `RetraceTrajectory` will automatically use this target to update its `AbstractQNetwork`. 

I'll leave this PR as a draft and only use it locally for now. When we move to 0.11 I'll adapt to make Retrace work with it.

