### PR TITLE
Fix parameter names for AsyncTrajectoryStyle

### DIFF
--- a/src/ReinforcementLearningCore/src/policies/agent.jl
+++ b/src/ReinforcementLearningCore/src/policies/agent.jl
@@ -19,7 +19,7 @@ mutable struct Agent{P,T} <: AbstractPolicy
     function Agent(policy::P, trajectory::T, cache=NamedTuple()) where {P,T}
         agent = new{P,T}(policy, trajectory, cache)
         if TrajectoryStyle(trajectory) === AsyncTrajectoryStyle()
-            bind(trajectory, @spawn(optimise!(p, t)))
+            bind(trajectory, @spawn(optimise!(policy, trajectory)))
         end
         agent
     end


### PR DESCRIPTION
When using **AsyncTrajectoryStyle**, _optimise!_ was called with _p_ and _t_ as parameters rather than _policy_ and _trajectory_.