### PR TITLE
Update DoEveryNEpisode hook to new api

### DIFF
--- a/src/ReinforcementLearningCore/src/core/hooks.jl
+++ b/src/ReinforcementLearningCore/src/core/hooks.jl
@@ -276,7 +276,7 @@ mutable struct DoEveryNEpisode{S<:Union{PreEpisodeStage,PostEpisodeStage},F} <: 
     t::Int
 end
 
-DoEveryNEpisode(f::F; n=1, t=0, stage::S=POST_EPISODE_STAGE) where {S,F} =
+DoEveryNEpisode(f::F; n=1, t=0, stage::S=PostEpisodeStage()) where {S,F} =
     DoEveryNEpisode{S,F}(f, n, t)
 
 function (hook::DoEveryNEpisode{S})(::S, agent, env) where {S}


### PR DESCRIPTION
DoEveryNEpisode hook was called with stage=POST_EPISODE_STAGE as default rather than PostEpisodeStage().

Not sure how this is meant to work in the future, but this is at least a temporary fix.