### PR TITLE
Update TwinNetwork

### DIFF
--- a/src/ReinforcementLearningCore/src/utils/networks.jl
+++ b/src/ReinforcementLearningCore/src/utils/networks.jl
@@ -514,7 +514,9 @@ end
 
 TwinNetwork(x; kw...) = TwinNetwork(; source=x, target=deepcopy(x), kw...)
 
-@functor TwinNetwork (source,)
+@functor TwinNetwork (source, target)
+
+Flux.trainable(model::TwinNetwork) = (model.source,)
 
 (model::TwinNetwork)(args...) = model.source(args...)
 


### PR DESCRIPTION
TwinNetwork only included `source` as a field in the functor, which made it difficult to move the source and target models onto the same device.