### PR TITLE
Add a developer mode

### DIFF
--- a/.cspell/julia_words.txt
+++ b/.cspell/julia_words.txt
@@ -5284,3 +5284,4 @@ inworld
 Posteriori
 normalised
 kldivergence
+devmode

--- a/src/ReinforcementLearning.jl
+++ b/src/ReinforcementLearning.jl
@@ -5,6 +5,8 @@ const RL = ReinforcementLearning
 
 using Reexport
 
+include("devmode.jl")
+
 @reexport using ReinforcementLearningBase
 @reexport using ReinforcementLearningCore
 @reexport using ReinforcementLearningEnvironments

--- a/src/devmode.jl
+++ b/src/devmode.jl
@@ -1,0 +1,26 @@
+using Pkg
+
+function activate_devmode!()
+    @info "Switching to dev mode. You are now using your local versions of the RL.jl packages instead of the registered releases."
+    #RLBase
+    #No dependency to dev
+    #RLCore
+    Pkg.activate("src/ReinforcementLearningCore")
+    Pkg.develop(path="src/ReinforcementLearningBase")
+    #RLZoo
+    Pkg.activate("src/ReinforcementLearningZoo")
+    Pkg.develop(path="src/ReinforcementLearningCore")
+    Pkg.develop(path="src/ReinforcementLearningBase")    
+    #RLEnvironments
+    Pkg.activate("src/ReinforcementLearningEnvironments")
+    Pkg.develop(path="src/ReinforcementLearningBase")
+    #RLExperiments
+    Pkg.activate("src/ReinforcementLearningExperiments")
+    Pkg.develop(path=".")
+    #RL
+    Pkg.activate(".")
+    Pkg.develop(path="src/ReinforcementLearningZoo")
+    Pkg.develop(path="src/ReinforcementLearningEnvironments")
+    Pkg.develop(path="src/ReinforcementLearningCore")
+    Pkg.develop(path="src/ReinforcementLearningBase")
+end

--- a/src/devmode.jl
+++ b/src/devmode.jl
@@ -1,5 +1,14 @@
 using Pkg
 
+"""
+    activate_devmode!()
+
+This will automatically dev all the packages of the RL.jl ecosystem (make sure your 
+working directory is ReinforcementLearning.jl). You should do this when you 
+create a new branch for a new PR and voilà, you're good to go. This function imitates 
+the process in the `ci.yml` file. This means that tests that you run locally should 
+work in github's CI.
+"""
 function activate_devmode!()
     @info "Switching to dev mode. You are now using your local versions of the RL.jl packages instead of the registered releases."
     #RLBase


### PR DESCRIPTION
Making contributions to the package is not an easy task due to package requirements. 
A single contribution is likely to span several packages and it would be a cumbersome workflow to make separate PRs in the different packages and wait for a release to be able to continue the PR. Hence, it is preferable to `dev` each package to work with a local version of all packages of the ecosystem. 

However this must be done in a particular order to avoid dependency conflicts, and it is also a long and annoying process to do.

This PR adds a (non-exported) function `ReinforcementLearning.activate_devmode!()`. This will automatically dev all the packages. Essentially, you should do this when you create a new branch for a new PR and voilà, you're good to go. This function imitates the process in the `ci.yml` file. This means that tests that you run locally should work in github's CI aswell (this was not the case before).