### PR TITLE
Pin ReinforcementLearning.jl to pre-refactor versions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # ReinforcementLearning.jl Release Notes
 
-## ReinforcementLearning.jl@v0.10.0
+## ReinforcementLearning.jl@v0.10.2
+
+- Pin sub-packages to pre-refactor versions
 
 ### ReinforcementLearningExperiments.jl
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReinforcementLearning"
 uuid = "158674fc-8238-5cab-b5ba-03dfc80d1318"
 authors = ["Johanni Brea <jbrea@users.noreply.github.com>", "Jun Tian <tianjun.cpp@gmail.com>"]
-version = "0.11.0"
+version = "0.10.2"
 
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -14,6 +14,10 @@ ReinforcementLearningZoo = "d607f57d-ee1e-4ba7-bcf2-7734c1e31854"
 [compat]
 Reexport = "0.2, 1"
 julia = "1.6"
+ReinforcementLearningBase = "0.9"
+ReinforcementLearningCore = "0.8"
+ReinforcementLearningEnvironments = "0.6"
+ReinforcementLearningZoo = "0.5"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
In theory, this PR would allow us to tag a `v0.10.2` version of `ReinforcementLearning.jl` which only uses pre-refactor versions of the packages. This should make it possible to consistently tag newer versions of the sub-packages e.g. `ReinforcementLearningBase.jl`, etc. as we work towards shipping a `v0.11` of the overall package.

- [ ] After this PR is merged, tag new version of RL.jl

@findmyway @HenriDeh Thoughts?