### PR TITLE
DoEvery should not trigger on t = 1

### DIFF
--- a/src/ReinforcementLearningCore/src/core/hooks.jl
+++ b/src/ReinforcementLearningCore/src/core/hooks.jl
@@ -323,7 +323,7 @@ end
 
 function (hook::DoEveryNStep)(::PostActStage, agent, env)
     hook.t += 1
-    if hook.t % hook.n == 0 && (hook.t > 1 || hook.n == 1)
+    if hook.t % hook.n == 0
         hook.f(hook.t, agent, env)
     end
     return
@@ -346,7 +346,7 @@ DoEveryNEpisode(f::F; n=1, t=0, stage::S=PostEpisodeStage()) where {S,F} =
 
 function (hook::DoEveryNEpisode{S})(::S, agent, env) where {S}
     hook.t += 1
-    if hook.t % hook.n == 0 && (hook.t > 1 || hook.n == 1)
+    if hook.t % hook.n == 0
         hook.f(hook.t, agent, env)
     end
     return

--- a/src/ReinforcementLearningCore/src/core/hooks.jl
+++ b/src/ReinforcementLearningCore/src/core/hooks.jl
@@ -323,7 +323,7 @@ end
 
 function (hook::DoEveryNStep)(::PostActStage, agent, env)
     hook.t += 1
-    if hook.t % hook.n == 0
+    if hook.t % hook.n == 0 && (hook.t > 1 || hook.n == 1)
         hook.f(hook.t, agent, env)
     end
     return
@@ -346,7 +346,7 @@ DoEveryNEpisode(f::F; n=1, t=0, stage::S=PostEpisodeStage()) where {S,F} =
 
 function (hook::DoEveryNEpisode{S})(::S, agent, env) where {S}
     hook.t += 1
-    if hook.t % hook.n == 0
+    if hook.t % hook.n == 0 && (hook.t > 1 || hook.n == 1)
         hook.f(hook.t, agent, env)
     end
     return

--- a/src/ReinforcementLearningCore/test/core/hooks.jl
+++ b/src/ReinforcementLearningCore/test/core/hooks.jl
@@ -78,9 +78,10 @@ end
         env = RandomWalk1D()
         env.pos = 1
         policy = RandomPolicy(legal_action_space(env))
-        [h(PostActStage(), policy, env) for i in 1:4]
-        @test env.pos == 3
-
+        for t = 1:4
+            h(PostActStage(), policy, env)
+            @test env.pos == 1+ div(t,2)
+        end
         test_noop!(h, stages=[PreActStage(), PreEpisodeStage(), PostEpisodeStage(), PreExperimentStage(), PostExperimentStage()])
     end
 end
@@ -165,8 +166,10 @@ end
         env = RandomWalk1D()
         env.pos = 1
         policy = RandomPolicy(legal_action_space(env))
-        [h(stage, policy, env) for j in 1:4]
-        @test env.pos == 3
+        for t in 1:4
+            h(stage, policy, env)
+            @test env.pos == 1 + div(t,2)
+        end     
         test_noop!(h, stages=[PreActStage(), PostActStage(), PreExperimentStage(), PostExperimentStage()])
     end
 end

--- a/src/ReinforcementLearningCore/test/core/hooks.jl
+++ b/src/ReinforcementLearningCore/test/core/hooks.jl
@@ -72,7 +72,7 @@ end
 
 @testset "DoEveryNStep" begin
     h_1 = DoEveryNStep((hook, agent, env) -> (env.pos += 1); n=2)
-    h_2 = DoEveryNStep((hook, agent, env) -> (env.pos += 1); n=2)
+    h_2 = DoEveryNStep((hook, agent, env) -> (env.pos += 1); n=1)
 
     for h in (h_1, h_2)
         env = RandomWalk1D()
@@ -80,7 +80,7 @@ end
         policy = RandomPolicy(legal_action_space(env))
         for t = 1:4
             h(PostActStage(), policy, env)
-            @test env.pos == 1+ div(t,2)
+            @test env.pos == 1+ div(t,h.n)
         end
         test_noop!(h, stages=[PreActStage(), PreEpisodeStage(), PostEpisodeStage(), PreExperimentStage(), PostExperimentStage()])
     end
@@ -156,7 +156,7 @@ end
 @testset "DoEveryNEpisode" begin
     h_1 = DoEveryNEpisode((hook, agent, env) -> (env.pos += 1); n=2, stage=PreEpisodeStage())
     h_2 = DoEveryNEpisode((hook, agent, env) -> (env.pos += 1); n=2, stage=PostEpisodeStage())
-    h_3 = DoEveryNEpisode((hook, agent, env) -> (env.pos += 1); n=2)
+    h_3 = DoEveryNEpisode((hook, agent, env) -> (env.pos += 1); n=1)
     h_list = (h_1, h_2, h_3)
     stage_list = (PreEpisodeStage(), PostEpisodeStage(), PostEpisodeStage())
 
@@ -168,7 +168,7 @@ end
         policy = RandomPolicy(legal_action_space(env))
         for t in 1:4
             h(stage, policy, env)
-            @test env.pos == 1 + div(t,2)
+            @test env.pos == 1 + div(t,h.n)
         end     
         test_noop!(h, stages=[PreActStage(), PostActStage(), PreExperimentStage(), PostExperimentStage()])
     end


### PR DESCRIPTION
Currently, DoEvery hooks trigger at the first step (because `x % 1 == 0`). But unless we want them to trigger every step/episode, we do not want them to trigger at t = 1.

PR Checklist

- [x] Update NEWS.md?
- [x] Unit tests for all structs / functions?
- [x] Integration and correctness tests using a simple env?
- [x] PR Review?
- [x] Add or update documentation?
- [x] Write docstrings for new methods?
