### PR TITLE
Tweak CI to check on dep changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,17 +159,23 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
+      - uses: marceloprado/has-changed-path@v1
+            id: documentation-changed
+            with:
+              paths: docs
       - uses: actions/checkout@v3
       - name: Setup python
+        if: (steps.documentation-changed.outputs.changed == 'true')
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.arch }}
-      - run: python -m pip install --user matplotlib
+        run: python -m pip install --user matplotlib
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.8'
+          version: '1'
       - name: Build homepage
+        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           cd docs/homepage
           julia --project --color=yes -e '
@@ -179,6 +185,7 @@ jobs:
             optimize()' > build.log
 
       - name: Make sure homepage is generated without error
+        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           if grep -1 "Franklin Warning" build.log; then
             echo "Franklin reported a warning"
@@ -188,6 +195,7 @@ jobs:
           fi
 
       - name: Build docs
+        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           cd docs
           julia --project --color=yes -e '
@@ -196,6 +204,7 @@ jobs:
           mv build homepage/__site/docs
 
       - name: Deploy to the main repo
+        if: (steps.documentation-changed.outputs.changed == 'true')
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,17 +165,16 @@ jobs:
               paths: docs
       - uses: actions/checkout@v3
       - name: Setup python
-        if: (steps.documentation-changed.outputs.changed == 'true')
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.arch }}
+        if: (steps.documentation-changed.outputs.changed == 'true')
         run: python -m pip install --user matplotlib
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
       - name: Build homepage
-        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           cd docs/homepage
           julia --project --color=yes -e '
@@ -185,7 +184,6 @@ jobs:
             optimize()' > build.log
 
       - name: Make sure homepage is generated without error
-        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           if grep -1 "Franklin Warning" build.log; then
             echo "Franklin reported a warning"
@@ -195,7 +193,6 @@ jobs:
           fi
 
       - name: Build docs
-        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           cd docs
           julia --project --color=yes -e '
@@ -204,7 +201,6 @@ jobs:
           mv build homepage/__site/docs
 
       - name: Deploy to the main repo
-        if: (steps.documentation-changed.outputs.changed == 'true')
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1'
+          - '1.8'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           paths: src/ReinforcementLearningCore
 
       - name: Test RLCore
-        if: (steps.RLCore-changed.outputs.changed == 'true') || (contains(github.event.pull_request.labels.*.name, 'Integration Test'))
+        if: (steps.RLBase-changed.outputs.changed == 'true') || (steps.RLCore-changed.outputs.changed == 'true') || (contains(github.event.pull_request.labels.*.name, 'Integration Test'))
         run: |
           julia --color=yes -e '
             using Pkg;
@@ -88,7 +88,7 @@ jobs:
           paths: src/ReinforcementLearningZoo
 
       - name: Test RLZoo
-        if: (steps.RLZoo-changed.outputs.changed == 'true') || (contains(github.event.pull_request.labels.*.name, 'Integration Test'))
+        if: (steps.RLBase-changed.outputs.changed == 'true') || (steps.RLCore-changed.outputs.changed == 'true') || (steps.RLZoo-changed.outputs.changed == 'true') || (contains(github.event.pull_request.labels.*.name, 'Integration Test'))
         run: |
           julia --color=yes -e '
             using Pkg;
@@ -104,7 +104,7 @@ jobs:
           paths: src/ReinforcementLearningEnvironments
 
       - name: Test RLEnvironments
-        if: (steps.RLEnvironments-changed.outputs.changed == 'true') || (contains(github.event.pull_request.labels.*.name, 'Integration Test'))
+        if: (steps.RLBase-changed.outputs.changed == 'true') || (steps.RLCore-changed.outputs.changed == 'true') || (steps.RLEnvironments-changed.outputs.changed == 'true') || (contains(github.event.pull_request.labels.*.name, 'Integration Test'))
         run: |
           julia --color=yes -e '
             using Pkg;
@@ -132,7 +132,7 @@ jobs:
           paths: src/ReinforcementLearningExperiments
 
       - name: Test RLExperiments
-        if: (steps.RLZoo-changed.outputs.changed == 'true') || (steps.RLExperiments-changed.outputs.changed == 'true') || (contains(github.event.pull_request.labels.*.name, 'Integration Test'))
+        if: (steps.RLBase-changed.outputs.changed == 'true') || (steps.RLCore-changed.outputs.changed == 'true') || (steps.RLZoo-changed.outputs.changed == 'true') || (steps.RLExperiments-changed.outputs.changed == 'true') || (contains(github.event.pull_request.labels.*.name, 'Integration Test'))
         run: |
           julia --color=yes -e '
             using Pkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.arch }}
-        run: python -m pip install --user matplotlib
+      - run: python -m pip install --user matplotlib
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
@@ -177,7 +177,6 @@ jobs:
             using NodeJS; run(`$(npm_cmd()) install highlight.js`);
             using Franklin;
             optimize()' > build.log
-
       - name: Make sure homepage is generated without error
         run: |
           if grep -1 "Franklin Warning" build.log; then
@@ -186,7 +185,6 @@ jobs:
           else
             echo "Franklin did not report a warning"
           fi
-
       - name: Build docs
         run: |
           cd docs
@@ -194,7 +192,6 @@ jobs:
             using Pkg; Pkg.instantiate();
             include("make.jl")'
           mv build homepage/__site/docs
-
       - name: Deploy to the main repo
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.8'
+          - '1'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.arch }}
-        if: (steps.documentation-changed.outputs.changed == 'true')
         run: python -m pip install --user matplotlib
       - uses: julia-actions/setup-julia@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,17 +159,23 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
+      - uses: marceloprado/has-changed-path@v1
+            id: documentation-changed
+            with:
+              paths: docs
       - uses: actions/checkout@v3
       - name: Setup python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.arch }}
-      - run: python -m pip install --user matplotlib
+      - if: (steps.documentation-changed.outputs.changed == 'true')
+        run: python -m pip install --user matplotlib
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.8'
+          version: '1'
       - name: Build homepage
+        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           cd docs/homepage
           julia --project --color=yes -e '
@@ -179,6 +185,7 @@ jobs:
             optimize()' > build.log
 
       - name: Make sure homepage is generated without error
+        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           if grep -1 "Franklin Warning" build.log; then
             echo "Franklin reported a warning"
@@ -188,6 +195,7 @@ jobs:
           fi
 
       - name: Build docs
+        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           cd docs
           julia --project --color=yes -e '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,23 +159,17 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: marceloprado/has-changed-path@v1
-            id: documentation-changed
-            with:
-              paths: docs
       - uses: actions/checkout@v3
       - name: Setup python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.arch }}
-      - if: (steps.documentation-changed.outputs.changed == 'true')
-        run: python -m pip install --user matplotlib
+      - run: python -m pip install --user matplotlib
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
       - name: Build homepage
-        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           cd docs/homepage
           julia --project --color=yes -e '
@@ -184,7 +178,6 @@ jobs:
             using Franklin;
             optimize()' > build.log
       - name: Make sure homepage is generated without error
-        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           if grep -1 "Franklin Warning" build.log; then
             echo "Franklin reported a warning"
@@ -193,7 +186,6 @@ jobs:
             echo "Franklin did not report a warning"
           fi
       - name: Build docs
-        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           cd docs
           julia --project --color=yes -e '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,23 +159,17 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: marceloprado/has-changed-path@v1
-            id: documentation-changed
-            with:
-              paths: docs
       - uses: actions/checkout@v3
       - name: Setup python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.arch }}
-      - if: (steps.documentation-changed.outputs.changed == 'true')
-        run: python -m pip install --user matplotlib
+      - run: python -m pip install --user matplotlib
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1'
+          version: '1.8'
       - name: Build homepage
-        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           cd docs/homepage
           julia --project --color=yes -e '
@@ -185,7 +179,6 @@ jobs:
             optimize()' > build.log
 
       - name: Make sure homepage is generated without error
-        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           if grep -1 "Franklin Warning" build.log; then
             echo "Franklin reported a warning"
@@ -195,7 +188,6 @@ jobs:
           fi
 
       - name: Build docs
-        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           cd docs
           julia --project --color=yes -e '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,17 +159,23 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
+      - uses: marceloprado/has-changed-path@v1
+            id: documentation-changed
+            with:
+              paths: docs
       - uses: actions/checkout@v3
       - name: Setup python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.arch }}
-      - run: python -m pip install --user matplotlib
+      - if: (steps.documentation-changed.outputs.changed == 'true')
+        run: python -m pip install --user matplotlib
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
       - name: Build homepage
+        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           cd docs/homepage
           julia --project --color=yes -e '
@@ -178,6 +184,7 @@ jobs:
             using Franklin;
             optimize()' > build.log
       - name: Make sure homepage is generated without error
+        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           if grep -1 "Franklin Warning" build.log; then
             echo "Franklin reported a warning"
@@ -186,6 +193,7 @@ jobs:
             echo "Franklin did not report a warning"
           fi
       - name: Build docs
+        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           cd docs
           julia --project --color=yes -e '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,16 +160,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: marceloprado/has-changed-path@v1
+        id: documentation-changed
+        with:
+          paths: docs
       - name: Setup python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.arch }}
-      - run: python -m pip install --user matplotlib
+      - if: (steps.documentation-changed.outputs.changed == 'true')
+        run: python -m pip install --user matplotlib
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
       - name: Build homepage
+        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           cd docs/homepage
           julia --project --color=yes -e '
@@ -178,6 +186,7 @@ jobs:
             using Franklin;
             optimize()' > build.log
       - name: Make sure homepage is generated without error
+        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           if grep -1 "Franklin Warning" build.log; then
             echo "Franklin reported a warning"
@@ -186,6 +195,7 @@ jobs:
             echo "Franklin did not report a warning"
           fi
       - name: Build docs
+        if: (steps.documentation-changed.outputs.changed == 'true')
         run: |
           cd docs
           julia --project --color=yes -e '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,10 +159,6 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: marceloprado/has-changed-path@v1
-            id: documentation-changed
-            with:
-              paths: docs
       - uses: actions/checkout@v3
       - name: Setup python
         uses: actions/setup-python@v4


### PR DESCRIPTION
Currently CI is setup to only check subpackages in which changes occurred. But a change in RLCore might break algorithms in Zoo, for example. Currently this would not be caught by CI. This tweak should make sure to trigger tests of subpackages if a dependency changed. 

I will make an impactless change to RLCore n the second commit to see if correctly triggers Envs and Zoo tests, it shouldn't trigger Base.
