### PR TITLE
Fix stack

### DIFF
--- a/docs/homepage/blog/ospp_report_210370190/index.md
+++ b/docs/homepage/blog/ospp_report_210370190/index.md
@@ -626,16 +626,16 @@ function RLBase.update!(
         # Vector of shape `(length(info_states), 1)`
         # compute expected reward from the start of `e` with policy_vs_best_reponse
         # baseline = ∑ₐ πᵢ(s, a) * q(s, a)
-        baseline = @ignore Flux.stack(([values_vs_br(policy_vs_br, e)] for e in info_states); dims=1) |> x -> _device(π, x)
+        baseline = @ignore stack(([values_vs_br(policy_vs_br, e)] for e in info_states); dims=1) |> x -> _device(π, x)
         
         # Vector of shape `(length(info_states), length(action_space))`
         # compute expected reward from the start of `e` when playing each action.
-        q_values = Flux.stack((q_value(π, policy_vs_br, e) for e in info_states); dims=1)
+        q_values = stack((q_value(π, policy_vs_br, e) for e in info_states); dims=1)
 
         advantage = q_values .- baseline
         # Vector of shape `(length(info_states), length(action_space))`
         # get the prob of each action with `e`, i.e., πᵢ(s, a).
-        policy_values = Flux.stack((prob(π, e, to_host = false) for e in info_states); dims=1)
+        policy_values = stack((prob(π, e, to_host = false) for e in info_states); dims=1)
 
         # get each info_state's loss
         # ∑ₐ πᵢ(s, a) * (q(s, a) - baseline), where baseline = ∑ₐ πᵢ(s, a) * q(s, a).

--- a/src/ReinforcementLearningCore/Project.toml
+++ b/src/ReinforcementLearningCore/Project.toml
@@ -42,7 +42,7 @@ ReinforcementLearningBase = "0.12"
 ReinforcementLearningTrajectories = "^0.1.9"
 StatsBase = "0.32, 0.33, 0.34"
 UnicodePlots = "1.3, 2, 3"
-julia = "1.6"
+julia = "1.9"
 
 [extras]
 DomainSets = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"

--- a/src/ReinforcementLearningCore/src/utils/distributions.jl
+++ b/src/ReinforcementLearningCore/src/utils/distributions.jl
@@ -60,7 +60,7 @@ batch_size).
 function mvnormlogpdf(μ::A, LorU::A, x::A; ϵ=1.0f-8) where {A<:AbstractArray}
     it = zip(eachslice(μ, dims = 3), eachslice(LorU, dims = 3), eachslice(x, dims = 3))
     logp = [mvnormlogpdf(μs, LorUs, xs) for (μs, LorUs, xs) in it]
-    return unsqueeze(Flux.stack(logp; dims=2), dims=1)
+    return unsqueeze(stack(logp; dims=2), dims=1)
 end
 
 #Used for mvnormlogpdf and mvnormkldivergence

--- a/src/ReinforcementLearningCore/src/utils/networks.jl
+++ b/src/ReinforcementLearningCore/src/utils/networks.jl
@@ -143,7 +143,7 @@ If not sampling, returns `μ`
 with dimensions `(action_size x 1 x batch_size)` and `L`, the lower triangular of
 the cholesky decomposition of the covariance matrix, with dimensions
 `(action_size x action_size x batch_size)` The covariance matrices can be
-retrieved with `Σ = Flux.stack(map(l -> l*l', eachslice(L, dims=3)); dims=3)`
+retrieved with `Σ = stack(map(l -> l*l', eachslice(L, dims=3)); dims=3)`
 
 - `rng::AbstractRNG=Random.GLOBAL_RNG`
 - `is_sampling::Bool=false`, whether to sample from the obtained normal
@@ -212,7 +212,7 @@ function (model::CovGaussianNetwork)(rng::AbstractRNG, state::AbstractArray{<:An
     L = vec_to_tril(cholesky_vec, da)
     z = ignore_derivatives() do
         noise = randn(rng, eltype(μ), da, action_samples, batch_size)
-        Flux.stack(map(.+, eachslice(μ, dims=3), eachslice(L, dims=3) .* eachslice(noise, dims=3)); dims=3)
+        stack(map(.+, eachslice(μ, dims=3), eachslice(L, dims=3) .* eachslice(noise, dims=3)); dims=3)
     end
     logp_π = mvnormlogpdf(μ, L, z)
     return z, logp_π

--- a/src/ReinforcementLearningCore/test/utils/networks.jl
+++ b/src/ReinforcementLearningCore/test/utils/networks.jl
@@ -202,10 +202,10 @@ using Flux: params, gradient, unsqueeze
             @test size(logps) == (1,5,3)
             logps2 = gn(Flux.unsqueeze(state,dims = 2), as)
             @test logps2 ≈ logps
-            s = Flux.stack(map(l -> l*l', eachslice(L, dims=3)); dims=3)
+            s = stack(map(l -> l*l', eachslice(L, dims=3)); dims=3)
             mvnormals = map(z -> MvNormal(Array(vec(z[1])), Array(z[2])), zip(eachslice(m, dims = 3), eachslice(s, dims = 3)))
             logp_truth = [logpdf(mvn, a) for (mvn, a) in zip(mvnormals, eachslice(as, dims = 3))]
-            @test Flux.stack(logp_truth; dims=2) ≈ dropdims(logps,dims = 1) #test against ground truth
+            @test stack(logp_truth; dims=2) ≈ dropdims(logps,dims = 1) #test against ground truth
             action_saver = []
             g = Flux.gradient(Flux.params(gn)) do 
                 a, logp = gn(Flux.unsqueeze(state,dims = 2), is_sampling = true, is_return_log_prob = true)
@@ -261,7 +261,7 @@ using Flux: params, gradient, unsqueeze
                 @test size(logps) == (1,5,3)
                 logps2 = gn(Flux.unsqueeze(state,dims = 2), as)
                 @test logps2 ≈ logps
-                s = Flux.stack(map(l -> l*l', eachslice(L, dims=3)); dims=3)
+                s = stack(map(l -> l*l', eachslice(L, dims=3)); dims=3)
                 mvnormals = map(z -> MvNormal(Array(vec(z[1])), Array(z[2])), zip(eachslice(m, dims = 3), eachslice(s, dims = 3)))
                 logp_truth = [logpdf(mvn, cpu(a)) for (mvn, a) in zip(mvnormals, eachslice(as, dims = 3))]
                 @test reduce(hcat, collect(logp_truth)) ≈ dropdims(cpu(logps); dims=1) #test against ground truth

--- a/src/ReinforcementLearningExperiments/Project.toml
+++ b/src/ReinforcementLearningExperiments/Project.toml
@@ -25,7 +25,7 @@ ReinforcementLearningEnvironments = "0.8"
 ReinforcementLearningZoo = "0.7"
 StableRNGs = "1"
 Weave = "0.10"
-julia = "1.6"
+julia = "1.9"
 
 [extras]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/src/ReinforcementLearningZoo/Project.toml
+++ b/src/ReinforcementLearningZoo/Project.toml
@@ -31,7 +31,7 @@ ReinforcementLearningBase = "0.12"
 ReinforcementLearningCore = "0.10"
 StatsBase = "0.33, 0.34"
 Zygote = "0.6"
-julia = "1.6"
+julia = "1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/ReinforcementLearningZoo/src/algorithms/exploitability_descent/EDPolicy.jl
+++ b/src/ReinforcementLearningZoo/src/algorithms/exploitability_descent/EDPolicy.jl
@@ -94,20 +94,20 @@ function RLCore.update!(
         # Vector of shape `(length(info_states), 1)`
         # compute expected reward from the start of `e` with policy_vs_best_reponse
         # baseline = ∑ₐ πᵢ(s, a) * q(s, a)
-        baseline = @ignore Flux.stack(
+        baseline = @ignore stack(
             ([values_vs_br(policy_vs_br, e)] for e in info_states);
             dims=1,
         ) |> x -> _device(π, x)
 
         # Vector of shape `(length(info_states), length(action_space))`
         # compute expected reward from the start of `e` when playing each action.
-        q_values = Flux.stack((q_value(π, policy_vs_br, e) for e in info_states); dims=1)
+        q_values = stack((q_value(π, policy_vs_br, e) for e in info_states); dims=1)
 
         advantage = q_values .- baseline
         # Vector of shape `(length(info_states), length(action_space))`
         # get the prob of each action with `e`, i.e., πᵢ(s, a).
         policy_values =
-            Flux.stack((prob(π, e, to_host=false) for e in info_states); dims=1)
+            stack((prob(π, e, to_host=false) for e in info_states); dims=1)
 
         # get each info_state's loss
         # ∑ₐ πᵢ(s, a) * (q(s, a) - baseline), where baseline = ∑ₐ πᵢ(s, a) * q(s, a).


### PR DESCRIPTION
There was still an issue with stack. Because both Julia Base and Flux export stack, Flux cannot export stack anymore and I got `stack` not defined errors (e.g. with the MPOCovariance experiment). This is fixed by switching to the Base.stack function.
Problem: this limits the version of Julia to 1.9 or higher. Are we ok with this ?

PR Checklist

- [ ] Update NEWS.md?
- [ ] Unit tests for all structs / functions?
- [ ] Integration and correctness tests using a simple env?
- [ ] PR Review?
- [ ] Add or update documentation?
- [ ] Write docstrings for new methods?
