### PR TITLE
reintroduce args kwargs

### DIFF
--- a/src/ReinforcementLearningCore/src/policies/agent/base.jl
+++ b/src/ReinforcementLearningCore/src/policies/agent/base.jl
@@ -61,8 +61,8 @@ end
 # !!! TODO: In async scenarios, parameters of the policy may still be updating
 # (partially), which will result to incorrect action. This should be addressed
 # in Oolong.jl with a wrapper
-function RLBase.plan!(agent::Agent{P,T,C}, env::AbstractEnv) where {P,T,C}
-    action = RLBase.plan!(agent.policy, env)
+function RLBase.plan!(agent::Agent{P,T,C}, env::AbstractEnv, args...; kwargs...) where {P,T,C}
+    action = RLBase.plan!(agent.policy, env, args...; kwargs...)
     push!(agent.trajectory, agent.cache, action)
     action
 end

--- a/src/ReinforcementLearningCore/test/policies/agent.jl
+++ b/src/ReinforcementLearningCore/test/policies/agent.jl
@@ -71,10 +71,7 @@ using ReinforcementLearningCore
                 @test state(env) == agent.cache.state
                 @test RLBase.plan!(agent, env) in (1,2)
                 @test length(agent.trajectory.container) == 1
-
-                #The following tests checks args / kwargs passed to policy cause an error
-                @test_throws "MethodError: no method matching plan!(::Agent{RandomPolicy" RLBase.plan!(agent, env, 1)
-                @test_throws "MethodError: no method matching plan!(::Agent{RandomPolicy" RLBase.plan!(agent, env, fake_kwarg = 1)
+                
             end
 
             @testset "Test push! method" begin


### PR DESCRIPTION
Propagation of args and kwargs from the agent to the policy during `plan!` disappeared during the refactor. This reintroduces that.



