### PR TITLE
fixed problem with sequential multi agent envs

### DIFF
--- a/src/ReinforcementLearningCore/src/policies/agent/multi_agent.jl
+++ b/src/ReinforcementLearningCore/src/policies/agent/multi_agent.jl
@@ -186,14 +186,14 @@ function Base.push!(multiagent::MultiAgentPolicy, stage::S, env::E) where {S<:Ab
 end
 
 # Like in the single-agent case, push! at the PreActStage() calls push! on each player with the state of the environment
-function Base.push!(multiagent::MultiAgentPolicy, ::PreActStage, env::E) where {E<:AbstractEnv}
+function Base.push!(multiagent::MultiAgentPolicy{names, T}, ::PreActStage, env::E) where {E<:AbstractEnv, names, T <: Agent}
     for player in players(env)
         push!(multiagent[player], state(env, player))
     end
 end
 
 # Like in the single-agent case, push! at the PostActStage() calls push! on each player with the reward and termination status of the environment
-function Base.push!(multiagent::MultiAgentPolicy, ::PostActStage, env::E) where {E<:AbstractEnv}
+function Base.push!(multiagent::MultiAgentPolicy{names, T}, ::PostActStage, env::E) where {E<:AbstractEnv, names, T <: Agent}
     for player in players(env)
         push!(multiagent[player].cache, reward(env, player), is_terminated(env))
     end

--- a/src/ReinforcementLearningCore/src/policies/agent/multi_agent.jl
+++ b/src/ReinforcementLearningCore/src/policies/agent/multi_agent.jl
@@ -112,7 +112,7 @@ function Base.run(
         push!(multiagent_policy, PreEpisodeStage(), env)
         push!(multiagent_hook, PreEpisodeStage(), multiagent_policy, env)
 
-        while !reset_condition(multiagent_policy, env) # one episode
+        while !(reset_condition(multiagent_policy, env) || is_stop) # one episode
             for player in CurrentPlayerIterator(env)
                 policy = multiagent_policy[player] # Select appropriate policy
                 hook = multiagent_hook[player] # Select appropriate hook
@@ -132,6 +132,10 @@ function Base.run(
                     push!(multiagent_policy, PreActStage(), env)
                     push!(multiagent_hook, PreActStage(), policy, env)
                     RLBase.plan!(multiagent_policy, env)  # let the policy see the last observation
+                    break
+                end
+
+                if reset_condition(multiagent_policy, env)
                     break
                 end
             end

--- a/src/ReinforcementLearningCore/src/policies/random_policy.jl
+++ b/src/ReinforcementLearningCore/src/policies/random_policy.jl
@@ -95,3 +95,5 @@ function RLBase.prob(
         0.0
     end
 end
+
+RLBase.push!(::RandomPolicy, ::Any) = nothing

--- a/src/ReinforcementLearningCore/src/policies/random_policy.jl
+++ b/src/ReinforcementLearningCore/src/policies/random_policy.jl
@@ -9,7 +9,7 @@ using FillArrays: Fill
 
 If `action_space` is `nothing`, then it will use the `legal_action_space` at
 runtime to randomly select an action. Otherwise, a random element within
-`action_space` is selected. 
+`action_space` is selected.
 
 !!! note
     You should always set `action_space=nothing` when dealing with environments
@@ -95,5 +95,3 @@ function RLBase.prob(
         0.0
     end
 end
-
-RLBase.push!(::RandomPolicy, ::Any) = nothing

--- a/src/ReinforcementLearningCore/test/policies/multi_agent.jl
+++ b/src/ReinforcementLearningCore/test/policies/multi_agent.jl
@@ -179,3 +179,18 @@ end
     @test [i for i in a][2] ∈ ['💎', '📃', '✂']
     @test RLBase.act!(env, a)
 end
+
+@testset "Sequential Environments correctly ended by termination signal"
+    rng = StableRNGs.StableRNG(123)
+    e = env = TicTacToeEnv()
+    m = MultiAgentPolicy(NamedTuple((player => RandomPolicy(;rng=rng) for player in players(e))))
+    hooks = MultiAgentHook(NamedTuple((p => EmptyHook() for p ∈ players(e))))
+
+    let err = nothing
+        try
+            x = run(m, e, StopAfterEpisode(10), hooks)
+        catch err
+        end
+        @test !(err isa Exception)
+    end
+end

--- a/src/ReinforcementLearningCore/test/policies/multi_agent.jl
+++ b/src/ReinforcementLearningCore/test/policies/multi_agent.jl
@@ -180,10 +180,10 @@ end
     @test RLBase.act!(env, a)
 end
 
-@testset "Sequential Environments correctly ended by termination signal"
-    rng = StableRNGs.StableRNG(123)
-    e = env = TicTacToeEnv()
-    m = MultiAgentPolicy(NamedTuple((player => RandomPolicy(;rng=rng) for player in players(e))))
+@testset "Sequential Environments correctly ended by termination signal" begin
+    #rng = StableRNGs.StableRNG(123)
+    e = TicTacToeEnv();
+    m = MultiAgentPolicy(NamedTuple((player => RandomPolicy() for player in players(e))))
     hooks = MultiAgentHook(NamedTuple((p => EmptyHook() for p ∈ players(e))))
 
     let err = nothing


### PR DESCRIPTION
This PR addresses an issue with the new version of `MultiAgentPolicy.` When a sequential environment is terminated by not the last but the first or intermediate player, the loop will continue, although the environment is terminated. This is not the expected behavior. I have added changes as well as a unit test for the TicTacToe environment testing this issue.

PR Checklist

- [x] Update NEWS.md?
- [x] Unit tests for all structs / functions?
- [x] Integration and correctness tests using a simple env?
- [ ] PR Review?
- [x] Add or update documentation?
- [x] Write docstrings for new methods?
