### PR TITLE
fix bug in masked, multi-dimensional state space multi-threaded envs

### DIFF
--- a/src/ReinforcementLearningZoo/src/algorithms/policy_gradient/multi_thread_env.jl
+++ b/src/ReinforcementLearningZoo/src/algorithms/policy_gradient/multi_thread_env.jl
@@ -131,7 +131,7 @@ function RLBase.is_terminated(env::MultiThreadEnv)
 end
 
 function RLBase.legal_action_space_mask(env::MultiThreadEnv)
-    N = ndims(env.states)
+    N = ndims(env.legal_action_space_mask)
     @sync for i in 1:length(env)
         @spawn selectdim(env.legal_action_space_mask, N, i) .=
             legal_action_space_mask(env[i])


### PR DESCRIPTION
This fixes what appears to be a copy/paste bug that affects multi-threaded envs where the state space of the wrapped environment has different dimensionality than the action space of that environment.

For an example environment that this breaks, see https://github.com/Graeme22/rlskedge

PR Checklist

- [ ] Update NEWS.md?
- [ ] Unit tests for all structs / functions?
- [ ] Integration and correctness tests using a simple env?
- [ ] PR Review?
- [ ] Add or update documentation?
- [x] Write docstrings for new methods?
