### PR TITLE
Fix multi thread env state in case N=1

### DIFF
--- a/src/ReinforcementLearningZoo/src/algorithms/policy_gradient/multi_thread_env.jl
+++ b/src/ReinforcementLearningZoo/src/algorithms/policy_gradient/multi_thread_env.jl
@@ -115,7 +115,12 @@ const MULTI_THREAD_ENV_CACHE = IdDict{AbstractEnv,Dict{Symbol,Array}}()
 function RLBase.state(env::MultiThreadEnv)
     N = ndims(env.states)
     @sync for i in 1:length(env)
-        @spawn selectdim(env.states, N, i) .= state(env[i])
+        @spawn begin
+            if N == 1
+                env.states[i] .= state(env[i])
+            else
+                selectdim(env.states, N, i) .= state(env[i])
+            end
     end
     env.states
 end
@@ -167,7 +172,7 @@ function RLBase.plan!(π::QBasedPolicy, env::MultiThreadEnv, ::FullActionSet, A)
     ]
 end
 
-function RLBase.plan!(π::QBasedPolicy, 
+function RLBase.plan!(π::QBasedPolicy,
     env::MultiThreadEnv,
     ::MinimalActionSet,
     ::Space{<:Vector{<:Base.OneTo{<:Integer}}},


### PR DESCRIPTION
I have come across an issue with `MultiThreadEnv` for an environment where the `state_space(envs[1]=` is not a `Space`. The error message is

ERROR: DimensionMismatch: cannot broadcast array to have fewer non-singleton dimensions

because `selectdim(menv.states, N, i)` in this case returned a
`0-dimensional view(::Vector{Vector{Float64}}, 1) with eltype Vector{Float64}`.

I belief this change should fix the problem.

PR Checklist

- [ ] Update NEWS.md?
- [ ] Unit tests for all structs / functions?
- [ ] Integration and correctness tests using a simple env?
- [ ] PR Review?
- [ ] Add or update documentation?
- [ ] Write docstrings for new methods?
