### PR TITLE
Prioritised DQN GPU

### DIFF
--- a/src/ReinforcementLearningZoo/src/algorithms/dqns/prioritized_dqn.jl
+++ b/src/ReinforcementLearningZoo/src/algorithms/dqns/prioritized_dqn.jl
@@ -42,6 +42,8 @@ function RLBase.optimise!(
     a = CartesianIndex.(a, 1:batch_size)
     k, p = batch.key, batch.priority
     p′ = similar(p)
+    s, s′, a, r, t = send_to_device(device(Q), (s, s′, a, r, t))
+    k, p, p′ = send_to_device(device(Q), (k, p, p′))
 
     w = 1.0f0 ./ ((p .+ 1.0f-10) .^ β)
     w ./= maximum(w)


### PR DESCRIPTION
Fixes #973. (Has been tested with `CUDA.allowscalar(false)`)

Two remarks
1. Currently, k and p' are returned as CuArrays. This does not seem to hamper the algorithm so I've not reverted them back, but if that is an issue it can be changed.
2. I have not included tests in the form of an experiment but simply modified the existing `JuliaRL_PrioritizedDQN_CartPole`. I can add that to the experiments but I think that it will just clutter the RLExperiments package.
