### PR TITLE
Fix abstract_learner for multiplayer games

### DIFF
--- a/src/ReinforcementLearningCore/src/core/stop_conditions.jl
+++ b/src/ReinforcementLearningCore/src/core/stop_conditions.jl
@@ -18,13 +18,13 @@ The result of `stop_conditions` is reduced by `reducer`. The default `reducer` i
 struct ComposedStopCondition{S,T} <: AbstractStopCondition
     stop_conditions::S
     reducer::T
-    function ComposedStopCondition(stop_conditions...; reducer = any)
-        new{typeof(stop_conditions),typeof(reducer)}(stop_conditions, reducer)
+    function ComposedStopCondition(stop_conditions...; reducer::T = any)
+        new{typeof(stop_conditions),T}(stop_conditions, reducer)
     end
 end
 
-function check!(s::ComposedStopCondition{S,T}, args...) where {S,T}
-    s.reducer(check!(sc, args...) for sc in s.stop_conditions)
+function check!(s::ComposedStopCondition{S,T}, policy::P, env::E) where {S,T,P<:AbstractPolicy,E<:AbstractEnv}
+    s.reducer(check!(sc, policy, env) for sc in s.stop_conditions)
 end
 
 #####
@@ -58,12 +58,12 @@ function _stop_after_step(s::StopAfterNSteps)
     res
 end
 
-function check!(s::StopAfterNSteps, args...)
+function check!(s::StopAfterNSteps, agent, env)
     ProgressMeter.next!(s.progress)
     _stop_after_step(s)
 end
 
-check!(s::StopAfterNSteps{Nothing}, args...) = _stop_after_step(s)
+check!(s::StopAfterNSteps{Nothing}, agent, env) = _stop_after_step(s)
 
 #####
 # StopAfterNEpisodes

--- a/src/ReinforcementLearningCore/src/core/stop_conditions.jl
+++ b/src/ReinforcementLearningCore/src/core/stop_conditions.jl
@@ -23,7 +23,7 @@ struct ComposedStopCondition{S,T} <: AbstractStopCondition
     end
 end
 
-function check!(s::ComposedStopCondition, args...)
+function check!(s::ComposedStopCondition{S,T}, args...) where {S,T}
     s.reducer(check!(sc, args...) for sc in s.stop_conditions)
 end
 

--- a/src/ReinforcementLearningCore/src/core/stop_conditions.jl
+++ b/src/ReinforcementLearningCore/src/core/stop_conditions.jl
@@ -15,15 +15,15 @@ abstract type AbstractStopCondition end
 
 The result of `stop_conditions` is reduced by `reducer`. The default `reducer` is the `any` function, which means that the condition is true when any one of the `stop_conditions...` is true. Can be replaced by any function returning a boolean. For example `reducer = x->sum(x) >= 2` will require at least two of the conditions to be true.
 """
-struct ComposedStopCondition{S,T} <: AbstractStopCondition
+struct ComposedStopCondition{S,reducer} <: AbstractStopCondition
     stop_conditions::S
-    reducer::T
-    function ComposedStopCondition(stop_conditions...; reducer::T = any) where {T}
-        new{typeof(stop_conditions),T}(stop_conditions, reducer)
+    reducer
+    function ComposedStopCondition(stop_conditions...; reducer = any)
+        new{typeof(stop_conditions),reducer}(stop_conditions, reducer)
     end
 end
 
-function check!(s::ComposedStopCondition{S,T}, policy::P, env::E) where {S,T,P<:AbstractPolicy,E<:AbstractEnv}
+function check!(s::ComposedStopCondition{S,R}, policy::P, env::E) where {S,R,P<:AbstractPolicy,E<:AbstractEnv}
     s.reducer(check!(sc, policy, env) for sc in s.stop_conditions)
 end
 

--- a/src/ReinforcementLearningCore/src/core/stop_conditions.jl
+++ b/src/ReinforcementLearningCore/src/core/stop_conditions.jl
@@ -18,7 +18,7 @@ The result of `stop_conditions` is reduced by `reducer`. The default `reducer` i
 struct ComposedStopCondition{S,T} <: AbstractStopCondition
     stop_conditions::S
     reducer::T
-    function ComposedStopCondition(stop_conditions...; reducer::T = any)
+    function ComposedStopCondition(stop_conditions...; reducer::T = any) where {T}
         new{typeof(stop_conditions),T}(stop_conditions, reducer)
     end
 end

--- a/src/ReinforcementLearningCore/src/policies/learners/abstract_learner.jl
+++ b/src/ReinforcementLearningCore/src/policies/learners/abstract_learner.jl
@@ -11,6 +11,11 @@ function forward(learner::L, env::E) where {L <: AbstractLearner, E <: AbstractE
     env |> state |> (x -> forward(learner, x))
 end
 
+# Take Learner and Environment, get state, send to RLCore.forward(Learner, State)
+function forward(learner::L, env::E, player::Symbol) where {L <: AbstractLearner, E <: AbstractEnv}
+    env |> (x -> state(x, player)) |> (x -> forward(learner, x))
+end
+
 function RLBase.optimise!(::AbstractLearner, ::AbstractStage, ::Trajectory) end
 
 function RLBase.plan!(explorer::AbstractExplorer, learner::AbstractLearner, env::AbstractEnv)
@@ -20,5 +25,5 @@ end
 
 function RLBase.plan!(explorer::AbstractExplorer, learner::AbstractLearner, env::AbstractEnv, player::Symbol)
     legal_action_space_ = RLBase.legal_action_space_mask(env, player)
-    return RLBase.plan!(explorer, forward(learner, env), legal_action_space_)
+    return RLBase.plan!(explorer, forward(learner, env, player), legal_action_space_)
 end

--- a/src/ReinforcementLearningCore/src/policies/learners/abstract_learner.jl
+++ b/src/ReinforcementLearningCore/src/policies/learners/abstract_learner.jl
@@ -18,6 +18,8 @@ end
 
 function RLBase.optimise!(::AbstractLearner, ::AbstractStage, ::Trajectory) end
 
+function RLBase.optimise!(::AbstractLearner, ::AbstractStage, ::NamedTuple) end
+
 function RLBase.plan!(explorer::AbstractExplorer, learner::AbstractLearner, env::AbstractEnv)
     legal_action_space_ = RLBase.legal_action_space_mask(env)
     RLBase.plan!(explorer, forward(learner, env), legal_action_space_)

--- a/src/ReinforcementLearningCore/src/policies/learners/td_learner.jl
+++ b/src/ReinforcementLearningCore/src/policies/learners/td_learner.jl
@@ -91,3 +91,6 @@ end
 # TDLearner{:SARS} is optimized at the PostActStage
 RLBase.optimise!(learner::TDLearner{:SARS}, stage::PostActStage, trace::NamedTuple) = RLBase.optimise!(learner, trace)
 
+RLBase.optimise!(agent::MultiAgentPolicy, stage::PreActStage) = nothing
+RLBase.optimise!(agent::MultiAgentPolicy, stage::PostEpisodeStage) = nothing
+RLBase.optimise!(agent::MultiAgentPolicy, stage::PreEpisodeStage) = nothing

--- a/src/ReinforcementLearningCore/src/policies/learners/td_learner.jl
+++ b/src/ReinforcementLearningCore/src/policies/learners/td_learner.jl
@@ -90,7 +90,3 @@ end
 
 # TDLearner{:SARS} is optimized at the PostActStage
 RLBase.optimise!(learner::TDLearner{:SARS}, stage::PostActStage, trace::NamedTuple) = RLBase.optimise!(learner, trace)
-
-RLBase.optimise!(agent::MultiAgentPolicy, stage::PreActStage) = nothing
-RLBase.optimise!(agent::MultiAgentPolicy, stage::PostEpisodeStage) = nothing
-RLBase.optimise!(agent::MultiAgentPolicy, stage::PreEpisodeStage) = nothing

--- a/src/ReinforcementLearningCore/src/policies/q_based_policy.jl
+++ b/src/ReinforcementLearningCore/src/policies/q_based_policy.jl
@@ -10,11 +10,15 @@ action of an environment at its current state. It is typically a table or a neur
 QBasedPolicy can be queried for an action with `RLBase.plan!`, the explorer will affect the action selection
 accordingly.
 """
-Base.@kwdef mutable struct QBasedPolicy{L<:TDLearner,E<:AbstractExplorer} <: AbstractPolicy
+struct QBasedPolicy{L<:TDLearner,E<:AbstractExplorer} <: AbstractPolicy
     "estimate the Q value"
     learner::L
     "select the action based on Q values calculated by the learner"
     explorer::E
+
+    function QBasedPolicy(;learner, explorer) where {L<:TDLearner,E<:AbstractExplorer}
+        new{L,E}(learner, explorer)
+    end
 end
 
 Flux.@layer QBasedPolicy trainable=(learner,)

--- a/src/ReinforcementLearningCore/src/policies/q_based_policy.jl
+++ b/src/ReinforcementLearningCore/src/policies/q_based_policy.jl
@@ -16,7 +16,11 @@ struct QBasedPolicy{L<:TDLearner,E<:AbstractExplorer} <: AbstractPolicy
     "select the action based on Q values calculated by the learner"
     explorer::E
 
-    function QBasedPolicy(;learner::L, explorer::E) where {L<:TDLearner,E<:AbstractExplorer}
+    function QBasedPolicy(; learner::L, explorer::E) where {L<:TDLearner, E<:AbstractExplorer}
+        new{L,E}(learner, explorer)
+    end
+
+    function QBasedPolicy(learner::L, explorer::E) where {L<:TDLearner, E<:AbstractExplorer}
         new{L,E}(learner, explorer)
     end
 end

--- a/src/ReinforcementLearningCore/src/policies/q_based_policy.jl
+++ b/src/ReinforcementLearningCore/src/policies/q_based_policy.jl
@@ -16,7 +16,7 @@ struct QBasedPolicy{L<:TDLearner,E<:AbstractExplorer} <: AbstractPolicy
     "select the action based on Q values calculated by the learner"
     explorer::E
 
-    function QBasedPolicy(;learner, explorer) where {L<:TDLearner,E<:AbstractExplorer}
+    function QBasedPolicy(;learner::L, explorer::E) where {L<:TDLearner,E<:AbstractExplorer}
         new{L,E}(learner, explorer)
     end
 end

--- a/src/ReinforcementLearningCore/test/core/stop_conditions.jl
+++ b/src/ReinforcementLearningCore/test/core/stop_conditions.jl
@@ -2,18 +2,24 @@ import ReinforcementLearningCore.check!
 
 @testset "StopAfterNSteps" begin
     stop_condition = StopAfterNSteps(10)
-    @test sum([check!(stop_condition) for i in 1:20]) == 11
+    env = RandomWalk1D()
+    policy = RandomPolicy(legal_action_space(env))
+
+    @test sum([check!(stop_condition, policy, env) for i in 1:20]) == 11
 
     stop_condition = StopAfterNSteps(10; is_show_progress=false)
-    @test sum([check!(stop_condition) for i in 1:20]) == 11
+    @test sum([check!(stop_condition, policy, env) for i in 1:20]) == 11
 end
 
 @testset "ComposedStopCondition" begin
     stop_10 = StopAfterNSteps(10)
     stop_3 = StopAfterNSteps(3)
 
+    env = RandomWalk1D()
+    policy = RandomPolicy(legal_action_space(env))
+
     composed_stop = ComposedStopCondition(stop_10, stop_3)
-    @test sum([check!(composed_stop) for i in 1:20]) == 18
+    @test sum([check!(composed_stop, policy, env) for i in 1:20]) == 18
 end
 
 @testset "StopAfterNEpisodes" begin

--- a/src/ReinforcementLearningCore/test/policies/learners/abstract_learner.jl
+++ b/src/ReinforcementLearningCore/test/policies/learners/abstract_learner.jl
@@ -15,6 +15,7 @@ struct MockLearner <: AbstractLearner end
         end
 
         RLBase.state(::MockEnv, ::Observation{Any}, ::DefaultPlayer) = 1
+        RLBase.state(::MockEnv, ::Observation{Any}, ::Symbol) = 1
 
         env = MockEnv()
         learner = MockLearner()

--- a/src/ReinforcementLearningCore/test/policies/learners/abstract_learner.jl
+++ b/src/ReinforcementLearningCore/test/policies/learners/abstract_learner.jl
@@ -21,6 +21,9 @@ struct MockLearner <: AbstractLearner end
 
         output = RLCore.forward(learner, env)
         @test output == Float64[1.0, 2.0]
+
+        output = RLCore.forward(learner, env, Symbol(1))
+        @test output == Float64[1.0, 2.0]
     end
 
     @testset "Plan" begin


### PR DESCRIPTION
This pull request fixes the abstract_learner for multiplayer games. It adds a new function `forward(learner::L, env::E, player::Symbol)` that takes a learner, environment, and player symbol as arguments and sends the state to `RLCore.forward(Learner, State)`. This ensures that the learner can handle multiplayer games correctly.

It also cleans up a few other minor issues along the way.