### PR TITLE
Fix for TicTacToeEnv allows illegal moves #1001

### DIFF
--- a/src/ReinforcementLearningEnvironments/src/environments/examples/TicTacToeEnv.jl
+++ b/src/ReinforcementLearningEnvironments/src/environments/examples/TicTacToeEnv.jl
@@ -60,6 +60,7 @@ end
 RLBase.act!(env::TicTacToeEnv, action::Int) = RLBase.act!(env, CartesianIndices((3, 3))[action])
 
 function RLBase.act!(env::TicTacToeEnv, action::CartesianIndex{2})
+    !env.board[action,1] && error("The state has already been played.")
     env.board[action, 1] = false
     env.board[action, Base.to_index(env, current_player(env))] = true
 end


### PR DESCRIPTION
TicTacToeEnv allows one state to be played multiple times by the same agent. This condition should prevent this behavior and throw an error in case the state is played multiple times.