### PR TITLE
docs: replace broken environment links with @ref cross-references

### DIFF
--- a/docs/src/rlenvs.md
+++ b/docs/src/rlenvs.md
@@ -27,19 +27,19 @@
 <tr> <th> ConstantSum </th><td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> ✔ </td><td> </td> <td> </td> <td> </td> <td> </td> <td> </td> </tr>
 <tr> <th> IdenticalUtility </th><td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> ✔ </td><td> </td> <td> </td> <td> </td> <td> </td> <td> </td> <td> </td> </tr>
 </table>
-<ol><li> <a href="https://juliareinforcementlearning.org/docs/rlenvs/#ReinforcementLearningEnvironments.MultiArmBanditsEnv-Tuple{}"> MultiArmBanditsEnv </a></li>
-<li> <a href="https://juliareinforcementlearning.org/docs/rlenvs/#ReinforcementLearningEnvironments.RandomWalk1D-Tuple{}"> RandomWalk1D </a></li>
-<li> <a href="https://juliareinforcementlearning.org/docs/rlenvs/#ReinforcementLearningEnvironments.TigerProblemEnv-Tuple{}"> TigerProblemEnv </a></li>
-<li> <a href="https://juliareinforcementlearning.org/docs/rlenvs/#ReinforcementLearningEnvironments.MontyHallEnv-Tuple{}"> MontyHallEnv </a></li>
-<li> <a href="https://juliareinforcementlearning.org/docs/rlenvs/#ReinforcementLearningEnvironments.RockPaperScissorsEnv-Tuple{}"> RockPaperScissorsEnv </a></li>
-<li> <a href="https://juliareinforcementlearning.org/docs/rlenvs/#ReinforcementLearningEnvironments.TicTacToeEnv-Tuple{}"> TicTacToeEnv </a></li>
-<li> <a href="https://juliareinforcementlearning.org/docs/rlenvs/#ReinforcementLearningEnvironments.TinyHanabiEnv-Tuple{}"> TinyHanabiEnv </a></li>
-<li> <a href="https://juliareinforcementlearning.org/docs/rlenvs/#ReinforcementLearningEnvironments.PigEnv-Tuple{}"> PigEnv </a></li>
-<li> <a href="https://juliareinforcementlearning.org/docs/rlenvs/#ReinforcementLearningEnvironments.KuhnPokerEnv-Tuple{}"> KuhnPokerEnv </a></li>
-<li> <a href="https://juliareinforcementlearning.org/docs/rlenvs/#ReinforcementLearningEnvironments.AcrobotEnv-Tuple{}"> AcrobotEnv </a></li>
-<li> <a href="https://juliareinforcementlearning.org/docs/rlenvs/#ReinforcementLearningEnvironments.CartPoleEnv-Tuple{}"> CartPoleEnv </a></li>
-<li> <a href="https://juliareinforcementlearning.org/docs/rlenvs/#ReinforcementLearningEnvironments.MountainCarEnv-Tuple{}"> MountainCarEnv </a></li>
-<li> <a href="https://juliareinforcementlearning.org/docs/rlenvs/#ReinforcementLearningEnvironments.PendulumEnv-Tuple{}"> PendulumEnv </a></li>
+<ol><li> MultiArmBanditsEnv </li>
+<li> RandomWalk1D </li>
+<li> TigerProblemEnv </li>
+<li> MontyHallEnv </li>
+<li> RockPaperScissorsEnv </li>
+<li> TicTacToeEnv </li>
+<li> TinyHanabiEnv </li>
+<li> PigEnv </li>
+<li> KuhnPokerEnv </li>
+<li> AcrobotEnv </li>
+<li> CartPoleEnv </li>
+<li> MountainCarEnv </li>
+<li> PendulumEnv </li>
 </ol>
 ```
 


### PR DESCRIPTION
Fixes part of #1060

All 13 environment links in the Built-in Environments table in `docs/src/rlenvs.md` pointed to `juliareinforcementlearning.org/docs/rlenvs/`which returns 404, causing doc build failures.

Replaced broken HTML anchor links with plain text environment names since the environment structs do not currently have docstrings for `@ref` resolution. This removes 13 linkcheck errors from the doc build.